### PR TITLE
modify the code in capture_wr.py and panoseti_snmp_demo.py.

### DIFF
--- a/control/capture_wr.py
+++ b/control/capture_wr.py
@@ -53,7 +53,7 @@ def wrsSFPCheck(wrs):
             failed = 0
             for i in range(len(res)):
                 if(len(res[i]) != 0):
-                    if(res[i] != SFP_PN0 and res[i] != SFP_PN1):
+                    if(res[i] != SFP_PN1):
                         failed = 1
                         print('WR-SWITCH(%s) : sfp%2d is %-16s[ FAIL ]' %(wrs.dev, i+1, res[i]))
                     else:
@@ -65,6 +65,7 @@ def wrsSFPCheck(wrs):
             else:
                 print(' ')
                 print('Error : Please check the sfp transceivers!!')
+                print('The part number of the sfp transceiver should be %s'%(SFP_PN1))
                 print(' ')
 
 # check the link status

--- a/control/panoseti_snmp_demo.py
+++ b/control/panoseti_snmp_demo.py
@@ -29,7 +29,7 @@ def wrsSFPCheck(wrs):
             failed = 0
             for i in range(len(res)):
                 if(len(res[i]) != 0):
-                    if(res[i] != SFP_PN0 and res[i] != SFP_PN1):
+                    if(res[i] != SFP_PN1):
                         failed = 1
                         print('WR-SWITCH(%s) : sfp%2d is %-16s[ FAIL ]' %(wrs.dev, i+1, res[i]))
                     else:
@@ -41,6 +41,7 @@ def wrsSFPCheck(wrs):
             else:
                 print(' ')
                 print('Error : Please check the sfp transceivers!!')
+                print('The part number of the sfp transceiver should be %s'%(SFP_PN1))
                 print(' ')
 
 # check the link status


### PR DESCRIPTION
In the previous design, SFP transceivers labeled with "PS-FB-TX1310" and "PS-FB-RX1310" are allowed to be used on WRS side.
Now, to get the best timing performance, only "PS-FB-RX1310" can be used on the WRS side.