### PR TITLE
Fix issue causing housekeeping scripts to save all metadata fields with string type

### DIFF
--- a/control/redis_utils.py
+++ b/control/redis_utils.py
@@ -2,6 +2,7 @@
 # Utility functions for communicating with redis and sending 
 # commands to redis databases
 ##############################################################
+import re
 import redis
 
 def redis_init():
@@ -21,3 +22,30 @@ def get_updated_redis_keys(r:redis.Redis, key_timestamps:dict):
         except redis.ResponseError:
             pass
     return list_of_updates
+
+def get_casted_redis_value(r:redis.Redis, rkey: [bytes, str], key: [bytes, str]):
+    """Returns val = r.hget(rkey, key) casted to int, float, or string
+     as follows:
+        1. int, if val has the form X where X.isnumeric(),
+        2. float, if val has the form (-)X.Y where X.isnumeric() and Y.isnumeric(),
+        3. string otherwise.
+    """
+    val = None
+    # Checks if val exists in the provided Redis database.
+    try:
+        val = r.hget(rkey, key)
+    except redis.RedisError as rerr:
+        msg = "redis_utils.py: A Redis error occurred: {0}."
+        print(msg.format(rerr))
+        pass
+    if val is not None:
+        val = val.decode('utf-8')
+        # Checks if val has the form X, with X numeric.
+        if val.isnumeric():
+            return int(val)
+        # Checks if val has the form (-)X.Y, with X and Y numeric.
+        pattern = re.compile("^-*([^\.]+)\.([^\.]+)$")
+        match = pattern.match(val)
+        if match and match.groups()[0].isnumeric() and match.groups()[1].isnumeric():
+            return float(val)
+        return val

--- a/control/storeInfluxDB.py
+++ b/control/storeInfluxDB.py
@@ -59,8 +59,9 @@ def write_influx(client:InfluxDBClient, key:str, data_fields:dict, datatype:str)
 
 def write_redis_to_influx(client:InfluxDBClient, r:redis.Redis, redis_keys:list, key_timestamps:dict):
     for rkey in redis_keys:
-        redis_value = r.hgetall(rkey)
-        data_fields = { k.decode('utf-8'): redis_value[k].decode('utf-8') for k in redis_value.keys() }
+        data_fields = dict()
+        for key in r.hkeys(rkey):
+            data_fields[key.decode('utf-8')] = get_casted_redis_value(r, rkey, key)
         write_influx(client, rkey, data_fields, get_datatype(rkey))
         key_timestamps[rkey] = data_fields['Computer_UTC']
 


### PR DESCRIPTION
redis_utils.py: Create the function get_casted_redis_value which gets a value from Redis and returns it with the proper type (int, float, or string) depending on its string representation.

storeInfluxDB.py: Modify the write_redis_to_influx method to use this new Redis util function.
