### PR TITLE
Fix bugs the function for setting individual detector hv and a method for converting TEMP1 to Celsius.

### DIFF
--- a/control/capture_hk.py
+++ b/control/capture_hk.py
@@ -38,7 +38,7 @@ signed = [
     0,                      # I10MON (182uA/LSB) (1.0V supply)
     0,                      # I18MON (37.8uA/LSB) (1.8V supply)
     0,                      # I33MON (37.8uA/LSB) (3.3V supply)
-    1,                        # TEMP1 (0.0625*N)
+    1,                        # TEMP1 (0.25*N)
     0,                      # TEMP2 (N/130.04-273.15)
     0,                      # VCCINT (N*3/65536)
     0,                      # VCCAUX (N*3/65536)

--- a/control/panosetiSIconvert.py
+++ b/control/panosetiSIconvert.py
@@ -60,7 +60,7 @@ class HKconvert():
         return self.I18MON(value)
 
     def TEMP1(self, value):
-        return value*0.0625
+        return value*0.25
     
     def TEMP2(self, value):
         return (value/130.04) - 273.15

--- a/control/quabo_driver.py
+++ b/control/quabo_driver.py
@@ -128,10 +128,10 @@ class QUABO:
 
     def hv_set_chan(self, chan, value):
         cmd = self.make_cmd(0x02)
-        self.HV_vals[chan] = value
+        self.HV_vals[chan] = int(value)
         for i in range(4):
-            LSbyte = HV_vals[i] & 0xff
-            MSbyte = (HV_vals[i] >> 8) & 0xff
+            LSbyte = self.HV_vals[i] & 0xff
+            MSbyte = (self.HV_vals[i] >> 8) & 0xff
             cmd[2*i+2]=LSbyte
             cmd[2*i+3]=MSbyte
         self.send(cmd)


### PR DESCRIPTION
quabo_driver: in hv_set_chan add 'self.' in front of HV_vals to fix bug.

panosetiSIconvert: change the function TEMP1 to return value * 0.25 instead of value * 0.0625. The new value is taken from the manufacturer's datasheet.

capture_hk.py: Change the comment for TEMP1 to reflect the change in panosetiSIconvert.