### PR TITLE
Hashpipe support for grouping pulse-height frames in any-trigger mode

### DIFF
--- a/control/daq_config_ucb2.json
+++ b/control/daq_config_ucb2.json
@@ -1,0 +1,13 @@
+{
+    "head_node_data_dir": "/data/panoseti/data",
+    "head_node_ip_addr": "192.168.1.100",
+    "daq_nodes": [
+        {
+            "username": "panoseti",
+            "data_dir": "/data/panoseti/data",
+            "ip_addr": "192.168.1.100",
+            "module_ids": "0-255",
+            "bindhost": "enp3s0"
+        }
+    ]
+}

--- a/control/data_config_ucb2.json
+++ b/control/data_config_ucb2.json
@@ -1,0 +1,13 @@
+{
+    "run_type": "engineering",
+    "image": {
+        "integration_time_usec": 1000
+    },
+    "max_file_size_mb": 0,
+    "pulse_height": {
+        "ph_threshold": 2,
+        "any_trigger": {
+            "group_ph_frames": 0
+        }
+    }
+}

--- a/control/obs_config_ucb.json
+++ b/control/obs_config_ucb.json
@@ -3,7 +3,7 @@
     "comment": "radio astronomy lab, 425 Campbell",
     "wps": {
         "url": "http://admin:1234@192.168.0.100",
-        "quabo_socket": 1
+        "quabo_socket": 6
     }, 
     "wr_ip_addr": "10.0.1.36",
     "gps_port": "/dev/ttyUSB5", 

--- a/control/quabo_driver.py
+++ b/control/quabo_driver.py
@@ -30,14 +30,18 @@ ACQ_IMAGE = 0x2
 ACQ_IMAGE_8BIT = 0x4
 ACQ_NO_BASELINE_SUBTRACT = 0x10
 
+
 class DAQ_PARAMS:
-    def __init__(self, do_image, image_us, image_8bit, do_ph, bl_subtract):
+    def __init__(self, do_image, image_us, image_8bit, do_ph, bl_subtract, do_any_trigger=False, do_group_frames=False):
         self.do_image = do_image
         self.image_us = image_us
         self.image_8bit = image_8bit
         self.do_ph = do_ph
         self.bl_subtract = bl_subtract
+        self.do_any_trigger = do_any_trigger
+        self.do_group_frames = do_group_frames
         self.do_flash = False
+
     def set_flash_params(self, rate, level, width):
         self.do_flash = True
         self.flash_rate = rate

--- a/control/quabo_driver.py
+++ b/control/quabo_driver.py
@@ -32,14 +32,14 @@ ACQ_NO_BASELINE_SUBTRACT = 0x10
 
 
 class DAQ_PARAMS:
-    def __init__(self, do_image, image_us, image_8bit, do_ph, bl_subtract, do_any_trigger=False, do_group_frames=False):
+    def __init__(self, do_image, image_us, image_8bit, do_ph, bl_subtract, do_any_trigger=False, do_group_ph_frames=False):
         self.do_image = do_image
         self.image_us = image_us
         self.image_8bit = image_8bit
         self.do_ph = do_ph
         self.bl_subtract = bl_subtract
         self.do_any_trigger = do_any_trigger
-        self.do_group_frames = do_group_frames
+        self.do_group_ph_frames = do_group_ph_frames
         self.do_flash = False
 
     def set_flash_params(self, rate, level, width):

--- a/control/start.py
+++ b/control/start.py
@@ -89,7 +89,7 @@ def get_daq_params(data_config):
                 raise Exception('missing "group_frames" param for "any_trigger" in data_config.json')
             if any_trigger['group_frames'] == 1:
                 do_group_frames = True
-            else:
+            elif any_trigger['group_frames'] != 0:
                 raise Exception('group_frames for any_trigger in data_config.json must be 0 or 1.')
     daq_params = quabo_driver.DAQ_PARAMS(
         do_image, image_usec - 1, image_8bit, do_ph, bl_subtract, do_any_trigger, do_group_frames

--- a/control/start.py
+++ b/control/start.py
@@ -68,7 +68,7 @@ def get_daq_params(data_config):
     do_ph = False
     bl_subtract = True
     do_any_trigger = False
-    do_group_frames = False
+    group_ph_frames = False
     if 'image' in data_config:
         do_image = True
         image = data_config['image']
@@ -85,14 +85,14 @@ def get_daq_params(data_config):
         if 'any_trigger' in data_config['pulse_height']:
             do_any_trigger = True
             any_trigger = data_config['pulse_height']['any_trigger']
-            if 'group_frames' not in any_trigger:
-                raise Exception('missing "group_frames" param for "any_trigger" in data_config.json')
-            if any_trigger['group_frames'] == 1:
-                do_group_frames = True
-            elif any_trigger['group_frames'] != 0:
-                raise Exception('group_frames for any_trigger in data_config.json must be 0 or 1.')
+            if 'group_ph_frames' not in any_trigger:
+                raise Exception('missing "group_ph_frames" param for "any_trigger" in data_config.json')
+            if any_trigger['group_ph_frames'] == 1:
+                group_ph_frames = True
+            elif any_trigger['group_ph_frames'] != 0:
+                raise Exception('group_ph_frames for any_trigger in data_config.json must be 0 or 1.')
     daq_params = quabo_driver.DAQ_PARAMS(
-        do_image, image_usec - 1, image_8bit, do_ph, bl_subtract, do_any_trigger, do_group_frames
+        do_image, image_usec - 1, image_8bit, do_ph, bl_subtract, do_any_trigger, group_ph_frames
     )
     if 'flash_params' in data_config:
         fp = data_config['flash_params']
@@ -219,8 +219,8 @@ def start_recording(data_config, daq_config, run_name, no_hv):
             continue
         username = node['username']
         data_dir = node['data_dir']
-        remote_cmd = './start_daq.py --daq_ip_addr %s --run_dir %s --max_file_size_mb %d --group_frames %d'%(
-            node['ip_addr'], run_name, max_file_size_mb, daq_params.do_group_frames
+        remote_cmd = './start_daq.py --daq_ip_addr %s --run_dir %s --max_file_size_mb %d --group_ph_frames %d'%(
+            node['ip_addr'], run_name, max_file_size_mb, daq_params.do_group_ph_frames
         )
         if 'bindhost' in node.keys():
             remote_cmd += ' --bindhost %s'%node['bindhost']

--- a/control/start_daq.py
+++ b/control/start_daq.py
@@ -28,7 +28,7 @@ def main():
     argv = sys.argv
     i = 1
     max_file_size_mb = -1
-    group_frames = 0
+    group_ph_frames = 0
     run_dir = None
     daq_ip_addr = None
     module_ids = []
@@ -43,9 +43,9 @@ def main():
         elif argv[i] == '--max_file_size_mb':
             i += 1
             max_file_size_mb = int(argv[i])
-        elif argv[i] == '--group_frames':
+        elif argv[i] == '--group_ph_frames':
             i += 1
-            group_frames = int(argv[i])
+            group_ph_frames = int(argv[i])
         elif argv[i] == '--module_id':
             i += 1
             module_ids.append(int(argv[i]))
@@ -83,7 +83,7 @@ def main():
     # create the run script
 
     f = open('run_hashpipe.sh', 'w')
-    f.write('hashpipe -p ./hashpipe.so -I 0 -o BINDHOST="%s" -o MAXFILESIZE=%d -o GROUPFRAMES=%d -o RUNDIR="%s" -o CONFIG="./module.config" -o OBS="LICK" net_thread compute_thread  output_thread > %s/%s%s'%(bindhost, max_file_size_mb, group_frames, run_dir, run_dir, util.hp_stdout_prefix, daq_ip_addr))
+    f.write('hashpipe -p ./hashpipe.so -I 0 -o BINDHOST="%s" -o MAXFILESIZE=%d -o GROUPPHFRAMES=%d -o RUNDIR="%s" -o CONFIG="./module.config" -o OBS="LICK" net_thread compute_thread  output_thread > %s/%s%s'%(bindhost, max_file_size_mb, group_ph_frames, run_dir, run_dir, util.hp_stdout_prefix, daq_ip_addr))
     f.close()
 
     # run the script

--- a/control/start_daq.py
+++ b/control/start_daq.py
@@ -28,6 +28,7 @@ def main():
     argv = sys.argv
     i = 1
     max_file_size_mb = -1
+    group_frames = 0
     run_dir = None
     daq_ip_addr = None
     module_ids = []
@@ -42,6 +43,9 @@ def main():
         elif argv[i] == '--max_file_size_mb':
             i += 1
             max_file_size_mb = int(argv[i])
+        elif argv[i] == '--group_frames':
+            i += 1
+            group_frames = int(argv[i])
         elif argv[i] == '--module_id':
             i += 1
             module_ids.append(int(argv[i]))
@@ -79,7 +83,7 @@ def main():
     # create the run script
 
     f = open('run_hashpipe.sh', 'w')
-    f.write('hashpipe -p ./hashpipe.so -I 0 -o BINDHOST="%s" -o MAXFILESIZE=%d -o RUNDIR="%s" -o CONFIG="./module.config" -o OBS="LICK" net_thread compute_thread  output_thread > %s/%s%s'%(bindhost, max_file_size_mb, run_dir, run_dir, util.hp_stdout_prefix, daq_ip_addr))
+    f.write('hashpipe -p ./hashpipe.so -I 0 -o BINDHOST="%s" -o MAXFILESIZE=%d -o GROUPFRAMES=%d -o RUNDIR="%s" -o CONFIG="./module.config" -o OBS="LICK" net_thread compute_thread  output_thread > %s/%s%s'%(bindhost, max_file_size_mb, group_frames, run_dir, run_dir, util.hp_stdout_prefix, daq_ip_addr))
     f.close()
 
     # run the script

--- a/control/stop.py
+++ b/control/stop.py
@@ -94,7 +94,7 @@ def make_links(run_dir, verbose):
             did_img = True
             if verbose:
                 print('linked %s to %s'%(img_symlink, f))
-        elif not did_ph and ftype == 'ph16':
+        elif not did_ph and ftype in ['ph256', 'ph1024']:
             os.symlink(path, ph_symlink)
             did_ph = True
             if verbose:

--- a/daq/compute_thread.c
+++ b/daq/compute_thread.c
@@ -21,7 +21,7 @@
 //
 #define NUM_OF_MODES 7
 
-// Store user input for the GROUPFRAMES option. 
+// Store user input for the GROUPPHFRAMES option. 
 // Equal to 0 (write 256 pixel PH images) or 1 (write 1024 pixel PH images).
 //
 static int group_ph_frames;
@@ -320,7 +320,7 @@ static int init(hashpipe_thread_args_t * args){
     FILE *modConfig_file = fopen(config_location, "r");
 
     // Fetch user input for whether to PH frames are to be grouped.
-    hgeti4(st.buf, "GROUPFRAMES", &group_ph_frames);
+    hgeti4(st.buf, "GROUPPHFRAMES", &group_ph_frames);
     if (group_ph_frames) {
         printf("Group frames is %i (True). Hashpipe will group incoming PH frames.\n", group_ph_frames);
     } else {

--- a/daq/compute_thread.c
+++ b/daq/compute_thread.c
@@ -21,6 +21,11 @@
 //
 #define NUM_OF_MODES 7
 
+// Store user input for the GROUPFRAMES option. 
+// Equal to 0 (write 256 pixel PH images) or 1 (write 1024 pixel PH images).
+//
+static int group_ph_frames;
+
 // copy image data from the module data to output buffer.
 //
 void write_frame_to_out_buffer(
@@ -45,7 +50,7 @@ void write_frame_to_out_buffer(
 //
 void write_ph_to_out_buffer(
     PH_IMAGE_BUFFER* ph_data,
-    HSD_output_block_t* out_block,      // block in output buffer
+    HSD_output_block_t* out_block      // block in output buffer
 ) {
     int out_index = out_block->header.n_ph_img;
     HSD_output_block_header_t* out_header = &(out_block->header);
@@ -242,7 +247,7 @@ void storeData(
         if (do_write) {    
             // A PH 1024 frame is now final.
 
-            write_frame_to_out_buffer(ph_data, out_block);
+            write_ph_to_out_buffer(ph_data, out_block);
 
             // clear PH frame buffer
             ph_data->clear();
@@ -294,9 +299,6 @@ static MODULE_IMAGE_BUFFER* moduleInd[MAX_MODULE_INDEX] = {NULL};
 //
 static PH_IMAGE_BUFFER* PHmoduleInd[MAX_MODULE_INDEX] = {NULL};
 
-// Store user input for GROUPFRAMES
-//
-static int group_ph_frames;
 
 // Initialization function
 // is called once when the thread is created

--- a/daq/compute_thread.c
+++ b/daq/compute_thread.c
@@ -187,9 +187,9 @@ void storeData(
         //--------------Process packet as a PH 256 image--------------
         //
         if (!group_ph_frames) {
-            // copy framing grouping setting
+            // Store header metadata
+            ph_data->ph_head.mod_num = in_block->header.pkt_head[pktIndex].mod_num;
             ph_data->ph_head.group_ph_frames = group_ph_frames; 
-
             // copy packet header 
             // Note: when grouping is disabled, all headers are stored at
             // index 0 of the packet header array for this block

--- a/daq/compute_thread.c
+++ b/daq/compute_thread.c
@@ -233,7 +233,6 @@ void storeData(
 
         // see if we should add PH 1024 frame to output buffer
         // - the quabo position of the new packet is already filled in pulse-height buf
-        // - or bytes/pixel is different (should never happen)
         // - or time threshold is exceeded
         //
         bool do_write = false;

--- a/daq/compute_thread.h
+++ b/daq/compute_thread.h
@@ -20,4 +20,20 @@ struct MODULE_IMAGE_BUFFER {
     }
 };
 
+// structure used by the compute thread to accumulate a pulse-height image;
+// only some of the quabo sub-images may be present
+
+struct PH_IMAGE_BUFFER {
+    uint32_t max_nanosec;       // min/max arrival times of quabo images
+    uint32_t min_nanosec;
+    char quabos_bitmap;         // bitmap for which quabos images are present
+    PH_IMAGE_HEADER ph_head;   // packet headers stored here
+    uint8_t data[BYTES_PER_PH_FRAME];
+    PH_IMAGE_BUFFER() {
+        clear();
+    }
+    void clear(){
+        memset(this, 0, sizeof(*this));
+    }
+};
 #endif

--- a/daq/databuf.h
+++ b/daq/databuf.h
@@ -143,13 +143,13 @@ struct MODULE_IMAGE_HEADER {
 // produced by the compute thread, consumed by the output thread
 // 
 struct PH_IMAGE_HEADER {
-    int group_frames;
+    int group_ph_frames;
     uint16_t mod_num;
     PACKET_HEADER pkt_head[QUABO_PER_MODULE];
     std::string toString(){
-        std::string return_string = "group_frames = " + std::to_string(this->group_frames) + "\n";
+        std::string return_string = "group_ph_frames = " + std::to_string(this->group_ph_frames) + "\n";
         return_string += "mod_num = " + std::to_string(this->mod_num);
-        if (this->group_frames) {
+        if (this->group_ph_frames) {
             for (int i = 0; i < QUABO_PER_MODULE; i++){
                 return_string += "\n" + pkt_head[i].toString();
             }

--- a/daq/databuf.h
+++ b/daq/databuf.h
@@ -78,7 +78,7 @@
     // Nanosecond threshold used for grouping quabo images
 
 #define PH_NANOSEC_THRESHOLD        25 
-    // Nanosecond threshold used for grouping PH images when grouping is enabled
+    // Nanosecond threshold used for grouping PH images when frame grouping is enabled
 
 // Module index is used for defining the array for storing pointers
 // of module structures for both compute and output threads.

--- a/daq/databuf.h
+++ b/daq/databuf.h
@@ -74,12 +74,11 @@
 // and the new module data is created starting with the new packet.
 // More information can be seen in the compute thread.
 
-#define NANOSEC_THRESHOLD        100
+#define IMG_NANOSEC_THRESHOLD       100
     // Nanosecond threshold used for grouping quabo images
 
-
-#define PH_NANOSEC_THRESHOLD        100
-    // Nanosecond threshold used for grouping PH images
+#define PH_NANOSEC_THRESHOLD        25 
+    // Nanosecond threshold used for grouping PH images when grouping is enabled
 
 // Module index is used for defining the array for storing pointers
 // of module structures for both compute and output threads.

--- a/daq/databuf.h
+++ b/daq/databuf.h
@@ -28,11 +28,11 @@
     // Number of blocks in the input buffer
 #define N_OUTPUT_BLOCKS             128
     // Number of blocks in the output buffer
-#define IN_PKT_PER_BLOCK            16384
+#define IN_PKT_PER_BLOCK            4096
     // Number of input packets stored in each block of the input buffer
-#define OUT_MOD_PER_BLOCK           16384
+#define OUT_MOD_PER_BLOCK           4096
     // Max Number of Modules stored in each block of the output buffer
-#define OUT_PH_IMG_PER_BLOCK        16384
+#define OUT_PH_IMG_PER_BLOCK        4096
     // Max # of PH packets stored in each block of the output buffer
 
 // Imaging Data Values and characteristics of modules

--- a/daq/databuf.h
+++ b/daq/databuf.h
@@ -28,11 +28,11 @@
     // Number of blocks in the input buffer
 #define N_OUTPUT_BLOCKS             128
     // Number of blocks in the output buffer
-#define IN_PKT_PER_BLOCK            4096
+#define IN_PKT_PER_BLOCK            16384
     // Number of input packets stored in each block of the input buffer
-#define OUT_MOD_PER_BLOCK           4096
+#define OUT_MOD_PER_BLOCK           16384
     // Max Number of Modules stored in each block of the output buffer
-#define OUT_PH_IMG_PER_BLOCK        4096
+#define OUT_PH_IMG_PER_BLOCK        16384
     // Max # of PH packets stored in each block of the output buffer
 
 // Imaging Data Values and characteristics of modules

--- a/daq/output_thread.c
+++ b/daq/output_thread.c
@@ -263,6 +263,7 @@ int write_ph_header_json(
 ){
     if (dataHeader->ph_img_head[frameIndex].group_ph_frames) {
         // Frame grouping is enabled. Write a 1024 pixel PH image.
+        // Note: PH1024 image headers have the same format as image mode headers.
         //
         fprintf(f, "{\n");
         for (int i=0; i<QUABO_PER_MODULE; i++){
@@ -339,11 +340,11 @@ int write_module_ph_file(HSD_output_block_t *dataBlock, int frameIndex){
 
     if (max_file_size && (ftell(f) > max_file_size)){
         moduleToWrite->ph_seqno++;
-        if (group_ph_frames) {
-            moduleToWrite->new_dp_file(DP_PH_1024_IMG, run_directory);
-        } else {
-            moduleToWrite->new_dp_file(DP_PH_256_IMG, run_directory);
-        }
+            if (group_ph_frames) {
+                moduleToWrite->new_dp_file(DP_PH_1024_IMG, run_directory);
+            } else {
+                moduleToWrite->new_dp_file(DP_PH_256_IMG, run_directory);
+            }
     }
     return 1;
 }

--- a/daq/output_thread.c
+++ b/daq/output_thread.c
@@ -339,12 +339,10 @@ int write_module_ph_file(HSD_output_block_t *dataBlock, int frameIndex){
 
     if (max_file_size && (ftell(f) > max_file_size)){
         moduleToWrite->ph_seqno++;
-        if (mode == 0x1){
-            if (group_ph_frames) {
-                moduleToWrite->new_dp_file(DP_PH_1024_IMG, run_directory);
-            } else {
-                moduleToWrite->new_dp_file(DP_PH_256_IMG, run_directory);
-            }
+        if (group_ph_frames) {
+            moduleToWrite->new_dp_file(DP_PH_1024_IMG, run_directory);
+        } else {
+            moduleToWrite->new_dp_file(DP_PH_256_IMG, run_directory);
         }
     }
     return 1;

--- a/daq/output_thread.c
+++ b/daq/output_thread.c
@@ -305,20 +305,15 @@ int write_ph_header_json(
 int write_module_ph_file(HSD_output_block_t *dataBlock, int frameIndex){
     FILE *f;
     FILE_PTRS *moduleToWrite = data_files[dataBlock->header.ph_img_head[frameIndex].mod_num];
-    char mode = dataBlock->header.ph_img_head[frameIndex].pkt_head[0].acq_mode;
     int group_ph_frames = dataBlock->header.ph_img_head[frameIndex].group_ph_frames;
-    int num_ph_frames_to_write = (group_ph_frames ? 4 : 1);
+    int num_ph_frames_to_write;
 
-    if (mode == 0x1) {
-        if (group_ph_frames) {
-            f = moduleToWrite->PH1024Img;
-        } else {
-            f = moduleToWrite->PH256Img;
-        }
+    if (group_ph_frames) {
+        f = moduleToWrite->PH1024Img;
+        num_ph_frames_to_write = 4;
     } else {
-        printf("Mode %c not recognized\n", mode);
-        printf("Module Header Value\n%s\n", dataBlock->header.img_mod_head[frameIndex].toString().c_str());
-        return 0;
+        f = moduleToWrite->PH256Img;
+        num_ph_frames_to_write = 1;
     }
 
     if (moduleToWrite == NULL){

--- a/daq/output_thread.c
+++ b/daq/output_thread.c
@@ -261,6 +261,8 @@ int write_ph_header_json(
     FILE *f, HSD_output_block_header_t *dataHeader, int frameIndex
 ){
     if (dataBlock->header.ph_img_head[frameIndex].group_ph_frames) {
+        // Frame grouping is enabled
+        //
         fprintf(f, "{\n");
         for (int i=0; i<QUABO_PER_MODULE; i++){
             fprintf(f,
@@ -281,7 +283,7 @@ int write_ph_header_json(
     } else {
         fprintf(f,
             "{ \"quabo_num\": %1u, \"pkt_num\": %10u, \"pkt_tai\": %4u, \"pkt_nsec\": %9u, \"tv_sec\": %10li, \"tv_usec\": %6li}",
-            0,
+            dataHeader->ph_img_head[frameIndex].pkt_head[0].quabo_num,
             dataHeader->ph_img_head[frameIndex].pkt_head[0].pkt_num,
             dataHeader->ph_img_head[frameIndex].pkt_head[0].pkt_tai,
             dataHeader->ph_img_head[frameIndex].pkt_head[0].pkt_nsec,
@@ -331,6 +333,8 @@ int write_module_ph_file(HSD_output_block_t *dataBlock, int frameIndex){
 
     pff_end_json(f);
 
+    // NOTE: when group_ph_frames=0, only the first 512 bytes of the PH data block
+    // will contain meaningful data.
     pff_write_image(f, 
         num_ph_frames_to_write*PIXELS_PER_IMAGE*2, 
         dataBlock->ph_block + (frameIndex*BYTES_PER_PH_FRAME)

--- a/daq/output_thread.c
+++ b/daq/output_thread.c
@@ -260,8 +260,8 @@ int write_module_img_file(HSD_output_block_t *dataBlock, int frameIndex){
 int write_ph_header_json(
     FILE *f, HSD_output_block_header_t *dataHeader, int frameIndex
 ){
-    if (dataBlock->header.ph_img_head[frameIndex].group_ph_frames) {
-        // Frame grouping is enabled
+    if (dataHeader->ph_img_head[frameIndex].group_ph_frames) {
+        // Frame grouping is enabled. Write a 1024 pixel PH image.
         //
         fprintf(f, "{\n");
         for (int i=0; i<QUABO_PER_MODULE; i++){

--- a/daq/output_thread.c
+++ b/daq/output_thread.c
@@ -255,8 +255,8 @@ int write_module_img_file(HSD_output_block_t *dataBlock, int frameIndex){
 
 // Write PH header information as JSON.  Fixed-length format.
 // Note:
-//      - If hashpipe is in grouping mode (group_ph_frames = 1), writes all 4 packet headers stored in the PH image header at frameIndex.
-//      - Otherwise (group_ph_frames = 0), writes only the packet header at index 0 in the PH image header at frameIndex.
+//      - If hashpipe is in grouping mode (group_ph_frames == 1), writes all 4 packet headers stored in the PH image header at frameIndex.
+//      - Otherwise (group_ph_frames == 0), writes only the packet header at index 0 in the PH image header at frameIndex.
 //
 int write_ph_header_json(
     FILE *f, HSD_output_block_header_t *dataHeader, int frameIndex
@@ -300,8 +300,8 @@ int write_ph_header_json(
 // dataBlock: Data block of the images to be written
 // frameIndex: The frame index for the specified output block.
 // Note: 
-//      - If hashpipe is in grouping mode (group_ph_frames = 1), writes the entire PH image block at frameIndex.
-//      - Otherwise (group_ph_frames = 0), writes only the first 512 bytes of the PH image block at frameIndex.
+//      - If hashpipe is in grouping mode (group_ph_frames == 1), writes the entire PH image block at frameIndex.
+//      - Otherwise (group_ph_frames == 0), writes only the first 512 bytes of the PH image block at frameIndex.
 //
 int write_module_ph_file(HSD_output_block_t *dataBlock, int frameIndex){
     FILE *f;
@@ -331,7 +331,7 @@ int write_module_ph_file(HSD_output_block_t *dataBlock, int frameIndex){
 
     pff_end_json(f);
 
-    // NOTE: when group_ph_frames=0, only the first 512 bytes of the PH data block
+    // NOTE: when group_ph_frames==0, only the first 512 bytes of the PH data block
     // will contain meaningful data.
     pff_write_image(f, 
         num_ph_frames_to_write*PIXELS_PER_IMAGE*2, 

--- a/daq/output_thread.c
+++ b/daq/output_thread.c
@@ -201,6 +201,7 @@ int write_img_header_json(
         fprintf(f, "\n");
     }
     fprintf(f, "}");
+    return 0;
 }
 
 // Write the image module structure to file
@@ -291,6 +292,7 @@ int write_ph_header_json(
             dataHeader->ph_img_head[frameIndex].pkt_head[0].tv_usec
         );
     }
+    return 0;
 }
 
 // Write a Pulse Height image to file
@@ -388,6 +390,7 @@ int create_data_files_from_config(){
     if (fclose(configFile) == EOF) {
         printf("Warning: Unable to close module configuration file.\n");
     }
+    return 0;
 }
 
 typedef enum {

--- a/util/pff.cpp
+++ b/util/pff.cpp
@@ -15,7 +15,8 @@ const char* dp_to_str(DATA_PRODUCT dp) {
     switch (dp) {
     case DP_BIT16_IMG: return "img16";
     case DP_BIT8_IMG: return "img8";
-    case DP_PH_IMG: return "ph16";
+    case DP_PH_256_IMG: return "ph256_bit16";
+    case DP_PH_1024_IMG: return "ph1024_bit16";
     }
     return "unknown";
 }
@@ -23,7 +24,8 @@ const char* dp_to_str(DATA_PRODUCT dp) {
 DATA_PRODUCT str_to_dp(const char* s) {
     if (!strcmp(s, "img16")) return DP_BIT16_IMG;
     if (!strcmp(s, "img8")) return DP_BIT8_IMG;
-    if (!strcmp(s, "ph16")) return DP_PH_IMG;
+    if (!strcmp(s, "ph256_bit16")) return DP_PH_256_IMG;
+    if (!strcmp(s, "ph1024_bit16")) return DP_PH_1024_IMG;
 }
 
 void pff_start_json(FILE* f) {

--- a/util/pff.cpp
+++ b/util/pff.cpp
@@ -26,6 +26,7 @@ DATA_PRODUCT str_to_dp(const char* s) {
     if (!strcmp(s, "img8")) return DP_BIT8_IMG;
     if (!strcmp(s, "ph256_bit16")) return DP_PH_256_IMG;
     if (!strcmp(s, "ph1024_bit16")) return DP_PH_1024_IMG;
+    return DP_NONE;
 }
 
 void pff_start_json(FILE* f) {

--- a/util/pff.cpp
+++ b/util/pff.cpp
@@ -15,8 +15,8 @@ const char* dp_to_str(DATA_PRODUCT dp) {
     switch (dp) {
     case DP_BIT16_IMG: return "img16";
     case DP_BIT8_IMG: return "img8";
-    case DP_PH_256_IMG: return "ph256_bit16";
-    case DP_PH_1024_IMG: return "ph1024_bit16";
+    case DP_PH_256_IMG: return "ph256";
+    case DP_PH_1024_IMG: return "ph1024";
     }
     return "unknown";
 }
@@ -24,8 +24,8 @@ const char* dp_to_str(DATA_PRODUCT dp) {
 DATA_PRODUCT str_to_dp(const char* s) {
     if (!strcmp(s, "img16")) return DP_BIT16_IMG;
     if (!strcmp(s, "img8")) return DP_BIT8_IMG;
-    if (!strcmp(s, "ph256_bit16")) return DP_PH_256_IMG;
-    if (!strcmp(s, "ph1024_bit16")) return DP_PH_1024_IMG;
+    if (!strcmp(s, "ph256")) return DP_PH_256_IMG;
+    if (!strcmp(s, "ph1024")) return DP_PH_1024_IMG;
     return DP_NONE;
 }
 

--- a/util/pff.h
+++ b/util/pff.h
@@ -38,14 +38,16 @@ extern bool ends_with(const char* s, const char* suffix);
 typedef enum {
     DP_BIT16_IMG = 1,       // this must be first
     DP_BIT8_IMG,
-    DP_PH_IMG,
+    DP_PH_256_IMG,
+    DP_PH_1024_IMG,
     DP_NONE                 // this must be last
 } DATA_PRODUCT;
 
 inline int bytes_per_pixel(DATA_PRODUCT dp) {
     if (dp == DP_BIT16_IMG) return 2;
     if (dp == DP_BIT8_IMG) return 1;
-    if (dp == DP_PH_IMG) return 2;
+    if (dp == DP_PH_256_IMG) return 2;
+    if (dp == DP_PH_1024_IMG) return 2;
 }
 
 // the info encoded in a dir name

--- a/util/pff.h
+++ b/util/pff.h
@@ -48,6 +48,7 @@ inline int bytes_per_pixel(DATA_PRODUCT dp) {
     if (dp == DP_BIT8_IMG) return 1;
     if (dp == DP_PH_256_IMG) return 2;
     if (dp == DP_PH_1024_IMG) return 2;
+    return DP_BIT16_IMG;
 }
 
 // the info encoded in a dir name


### PR DESCRIPTION
The following changes allow hashpipe to group the 4 pulse-height (PH) images produced by an any-trigger readout into a single 1024 pixel image. This behavior is not enabled by default and must be specified in data_config.json.

Databuf.h:
- Add a macro for the frame grouping nanosecond threshold for pulse-height images.
- Add a header struct for pulse-height images.
- Increase the number of bytes per PH frame from 512 to 2048, thus increasing the size of the PH output buffer.

Output_thread:
- Modify pulse-height file IO routines to write PH1024 images if PH frame grouping is enabled; otherwise, write PH256 images.
- PH1024 headers have the same format as image mode headers.
- PH256 headers formats are unchanged. 
- Create two new PH dataproduct types: “ph256” and “ph1024”.

Compute_thread:
- Add a struct to accumulate a PH1024 image.
- Add a grouping routine to group PH1024 images.

Python control scripts:
- Read data_config.json for the  “pulse_height”::“any_trigger”::“group_ph_frames” setting.
    - If PH frame grouping is enabled, hashpipe will group incoming PH frames into 1024 pixel images.
    - By default, hashpipe will write only 256 pixel PH images.
- Modify daq startup code to toggle the PH frame grouping behavior in hashpipe based on data_config.json.

Modify pulse-height related names to clarify whether they apply to 1) PH256 images exclusively, 2) PH1024 exclusively, or 3) any kind of PH image.

Add updated UCB lab configuration files.
