### PR TITLE
added SN040 and SN041 info to quabo_info.json.

### DIFF
--- a/control/quabos/quabo_info.json
+++ b/control/quabos/quabo_info.json
@@ -229,5 +229,27 @@
             1071,
             1074
         ]
+    },
+    {
+        "uid": "6b448240140d02e",
+        "serialno": "SN041",
+        "board_version": "bga",
+        "detector_serialno": [
+            1774,
+            1775,
+            1776,
+            1777
+        ]
+    },
+    {
+        "uid": "6b448240160642b",
+        "serialno": "SN040",
+        "board_version": "bga",
+        "detector_serialno": [
+            1770,
+            1771,
+            1772,
+            1773
+        ]
     }
 ]


### PR DESCRIPTION
We added the quabo UID, Quabo SN and detector SN for the two new quabos we are using at Palomar-Gattini.

The UID is from `quabo_uids.json`:
```
{
    "domes": [
        {
            "modules": [
                {
                    "ip_addr": "192.168.3.248",
                    "quabos": [
                        {
                            "uid": "6b448240140d02e"
                        },
                        {
                            "uid": "6b2110380604004"
                        },
                        {
                            "uid": "6b448240160642b"
                        },
                        {
                            "uid": "6b211038060d41c"
                        }
                    ]
                }
            ]
        }
    ]
}
```

The SN is from here:
```
Gattini:
First quabo: SN041 (det Q0-Q3: 1774, 1775, 1776, 1777)
Second quabo: SN030 (det Q0-Q3: 1238, 1239, 1240, 1241)
Third quabo: SN040 (det Q0-Q3: 1770, 1771, 1772, 1773)
Fourth quabo: SN037 (det Q0-Q3: 1070, 1072, 1071, 1074)
```