### PR TITLE
fixed baseline issue

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -486,7 +486,7 @@ def do_maroc_config(modules, quabo_uids, quabo_info, data_config, obs_config, da
 
 # set CHANMASK and GOEMASK for modules
 #
-def do_mask_config(modules, data_config, network_config, verbose=False):
+def do_mask_config(modules, data_config, network_config, quabo_uids, verbose=False):
     logger = logging.getLogger('PANOSETI.Config.do_mask_config')
     qc_dict = quabo_driver.parse_quabo_config_file('driver/quabo_config.txt')
     do_ph = 'pulse_height' in data_config.keys()
@@ -515,6 +515,8 @@ def do_mask_config(modules, data_config, network_config, verbose=False):
 
     for module in modules:
         for i in range(4):
+            uid = util.quabo_uid(module, quabo_uids, i)
+            if uid == '': continue
             ip_addr = config_file.quabo_ip_addr(module['ip_addr'], i)
             for tag in ['CHANMASK_8', 'GOEMASK']:
                 if verbose:
@@ -788,7 +790,7 @@ def main():
     elif args.maroc_config:
         do_maroc_config(modules, quabo_uids, quabo_info, data_config, obs_config, daq_config, network_config, True)
     elif args.mask_config:
-        do_mask_config(modules, data_config, network_config, True)
+        do_mask_config(modules, data_config, network_config, quabo_uids, True)
     elif args.calibrate_ph:
         do_calibrate_ph(modules, quabo_uids, network_config)
     elif args.disk_space:

--- a/control/driver/quabo_driver.py
+++ b/control/driver/quabo_driver.py
@@ -150,7 +150,7 @@ class QUABO:
                 image_us=4999,
                 image_8bit=False,
                 do_ph=True,
-                bl_subtract=True
+                bl_subtract=False
             )
         daq_stop = DAQ_PARAMS(False, 0, False, False, True)
         # This IP is not important, so I put a static IP here.

--- a/control/driver/quabo_tftp.py
+++ b/control/driver/quabo_tftp.py
@@ -41,7 +41,7 @@ class tftpw(object):
     #get flash_id
     def get_flashuid(self,filename='flashuid'):
         self.logger.info('get_flashuid: filename - %s'%filename)
-        self.client.download('/flashuid',filename)
+        self.client.download('/flashuid',filename, timeout=1)
         print('Get flash Device ID successfully!')
     
     #get wrpc_filesys

--- a/control/get_uids.py
+++ b/control/get_uids.py
@@ -17,10 +17,13 @@ from argparse import ArgumentParser
 #
 def get_uid(ip_addr, port):
     x = tftpw(ip_addr, port)
-    x.get_flashuid()
-    with open('flashuid', 'rb') as f:
-        i = struct.unpack('q', f.read(8))
-        return "%x"%(i[0])
+    try:
+        x.get_flashuid()
+        with open('flashuid', 'rb') as f:
+            i = struct.unpack('q', f.read(8))
+            return "%x"%(i[0])
+    except:
+        return ""
 
 def get_uids(obs_config, network_config, exclude=[]):
     quabo_uids = {}
@@ -42,7 +45,10 @@ def get_uids(obs_config, network_config, exclude=[]):
                     print("get uid", ip_addr)
                     # TODO: we need to ping the board before get_uid
                     uid = get_uid(real_ip, port)
-                    print("%s has UID %s"%(ip_addr, uid))
+                    if len(uid):
+                        print("%s has UID %s"%(ip_addr, uid))
+                    else:
+                        print("%s is offline"%ip_addr)
                     quabo['uid'] = uid
                 else:
                     quabo['uid'] = ''


### PR DESCRIPTION
(1) fixed the baseline issue (#240 and item 3 in #235):
     When we run `config.py --calibrate_ph`, we get some weird values sometime.
     The only way to fix this was to power cycle the telescopes.
     Now, running `config.py --calibrate_ph` again should fix this issue.

(2) skipped the mask config on the qubos which are offline.

(3) optimized the `get_uids.py`, making it not pop up error message if some of the quabos are offline.
