### PR TITLE
Update capture hk with gnss status for 10 MHz and 1PPS

### DIFF
--- a/control/configs/ucb/daq_config_ucb_router.json
+++ b/control/configs/ucb/daq_config_ucb_router.json
@@ -1,0 +1,13 @@
+{
+    "head_node_data_dir": "/data/panoseti/data",
+    "head_node_ip_addr": "192.168.88.1",
+    "daq_nodes": [
+        {
+            "username": "panoseti",
+            "data_dir": "/data/panoseti/data",
+            "ip_addr": "192.168.88.1",
+            "module_ids": "0-255",
+            "bindhost": "enp3s0"
+        }
+    ]
+}

--- a/control/configs/ucb/network_config_ucb_router.json
+++ b/control/configs/ucb/network_config_ucb_router.json
@@ -1,0 +1,33 @@
+{
+    "modules": [
+        {
+            "ip_addr": "192.168.3.248",
+            "port_forwarding": {
+                "status": true,
+                "gw_ip": "192.168.88.152",
+                "reboot_port": [
+                    69,
+                    60004,
+                    60005,
+                    60006
+                ],
+                "cmd_port": [
+                    60000,
+                    60001,
+                    60002,
+                    60003
+                ]
+            }
+        }
+    ],
+    "daq_nodes": [
+        {
+            "ip_addr": "192.168.88.1",
+            "port_forwarding": {
+                "status": true,
+                "gw_ip": "192.168.88.152",
+                "port": 22
+            }
+        }
+    ]
+}

--- a/control/daemons/capture_hk.py
+++ b/control/daemons/capture_hk.py
@@ -89,7 +89,11 @@ def storeInRedis(packet, r:redis.Redis):
     #       (array[(n - 2) // 2] & 0xFF00) >> 8, if n is odd.
     for i, sign in zip(range(2,len(packet), 2), signed):
         array.append(int.from_bytes(packet[i:i+2], byteorder='little', signed=sign))
-        
+
+
+    # See the following docs for the packet format in the housekeeping packet:
+    # https://github.com/panoseti/panoseti/wiki/Quabo-packet-interface#housekeeping-packet-64-bytes
+
     boardName = "QUABO_" + str(array[0])
     
     redis_set = {
@@ -126,6 +130,8 @@ def storeInRedis(packet, r:redis.Redis):
 
         'SHUTTER_STATUS': array[25]&0x01,
         'LIGHT_SENSOR_STATUS': (array[25]&0x02) >> 1,
+        'EXT_10MHz_STATUS': (array[25]&0x04) >> 2,      # 52[3]	EXT_10MHz_STATUS
+        'EXT_1PPS_STATUS': (array[25]&0x08) >> 3,       # 52[4]	EXT_1PPS_STATUS
 
         # PCBrev_n represents the quabo version. If 0, the quabo is BGA version; if 1, the qubao is QFP version
         # Bit 0 in the byte with offset 53.

--- a/control/daemons/capture_hk.py
+++ b/control/daemons/capture_hk.py
@@ -130,8 +130,6 @@ def storeInRedis(packet, r:redis.Redis):
 
         'SHUTTER_STATUS': array[25]&0x01,
         'LIGHT_SENSOR_STATUS': (array[25]&0x02) >> 1,
-        'EXT_10MHz_STATUS': (array[25]&0x04) >> 2,      # 52[3]	EXT_10MHz_STATUS
-        'EXT_1PPS_STATUS': (array[25]&0x08) >> 3,       # 52[4]	EXT_1PPS_STATUS
 
         # PCBrev_n represents the quabo version. If 0, the quabo is BGA version; if 1, the qubao is QFP version
         # Bit 0 in the byte with offset 53.
@@ -144,6 +142,13 @@ def storeInRedis(packet, r:redis.Redis):
         'AGG_STATUS_MSG': "",
         'AGG_STATUS_LEVEL': 0
     }
+
+    # Extract 10MHz and 1PPS
+    ext_10mhz_status = (array[25] & 0x08) >> 3  # 52[3] EXT_10MHz_STATUS
+    ext_1pps_status = (array[25] & 0x010) >> 4  # 52[4] EXT_1PPS_STATUS
+    redis_set['EXT_10MHz_STATUS'] = ext_10mhz_status
+    redis_set['EXT_1PPS_STATUS'] = ext_1pps_status & ext_10mhz_status  # 1PPs is valid only if 10 MHz is valid
+
     md_utils.write_status("housekeeping", boardName, redis_set)
 
     for x in range(4):


### PR DESCRIPTION
Modify capture_hk.py to parse the new EXT_10MHz_STATUS and EXT_1PPS_STATUS fields as described in issue #239.

See here for the full housekeeping packet encoding: https://github.com/panoseti/panoseti/wiki/Quabo-packet-interface#housekeeping-packet-64-bytes

We have tested this code in the UCB lab setup with the full redis -> influx -> grafana pipeline.