### PR TITLE
session_start and session_stop tested

### DIFF
--- a/control/config.py
+++ b/control/config.py
@@ -197,6 +197,10 @@ def do_reboot(modules, quabo_uids, network_config):
     print("Reboot Stop  Time :", end_dt.strftime("%Y-%m-%d %H:%M:%S"))
     print(f"Reboot Process Time: {minutes} minutes {seconds} seconds")
     print('*******************************************************')
+    if False in status:
+        return False
+    else:
+        return True
 
 def do_loads(modules, quabo_uids, quabo_info, network_config):
     logger = logging.getLogger('PANOSETI.Config.do_loads')

--- a/control/session_start.py
+++ b/control/session_start.py
@@ -14,42 +14,21 @@
 
 import sys, time, os
 
-import config, power, get_uids, util, file_xfer
+import config, power, get_uids, util
+from utils import config_file
 
-import skymap_helper
+from argparse import ArgumentParser
 
-sys.path.insert(0, '../util')
-import config_file
+def session_start(obs_config, quabo_info, data_config, daq_config, network_config, no_hv, stage ):
 
-def open_domes(obs_config):
-    print('Open the shutters of these domes:')
-    for dome in obs_config['domes']:
-        print('   ', dome['name'])
-
-def session_start(obs_config, quabo_info, data_config, daq_config, no_hv, stage = 'power_on'):
     modules = config_file.get_modules(obs_config)
-    
     # power on the telescopes
     if stage == 'poweron':
-        stage = 'ping'
-        open_domes(obs_config)
+        stage = 'get)uids'
         power.do_all(obs_config, 'on')
-        print('waiting 60 secs for quabos to come up')
-        time.sleep(60)      # wait for quabos to be pingable.  30 is not enough
+        print('waiting 60 secs for quabos to boot up')
+        time.sleep(60)
 
-    # Wait until all quabos are pingable
-    if stage == 'ping':
-        stage = 'get_uids'
-        all_pinged = False
-        while not all_pinged:
-            print("pinging quabos...")
-            ping_record = config.do_ping(modules, True)
-            if len(ping_record["ping_false"]) == 0:
-                print("pinged all quabos!")
-                all_pinged = True
-            else:
-                print("failed to ping all quabos. retrying in 5 seconds...")
-                time.sleep(5)
     if stage == 'get_uids':
         stage = 'reboot'
         print('getting quabo UIDs')
@@ -60,105 +39,61 @@ def session_start(obs_config, quabo_info, data_config, daq_config, no_hv, stage 
         stage = 'hk_dest'
         modules = config_file.get_modules(obs_config)
         print('rebooting quabos')
-        config.do_reboot(modules, quabo_uids)
+        status = config.do_reboot(modules, quabo_uids, network_config)
+        if status == False:
+            return
 
     if stage == 'hk_dest':
         stage = 'start_redis'
         print('setting hk dest to this computer')
-        config.do_hk_dest(modules, quabo_uids)
+        config.do_hk_dest(modules, quabo_uids, network_config)
 
     if stage == 'start_redis':
         stage = 'hv_on'
         print('starting Redis daemons')
         util.start_redis_daemons()
     
-    if stage == 'hv_on':
-        stage = 'mask_config'
-        if not no_hv:
-            print('turning on HV')
-            detector_info = config_file.get_detector_info()
-            #config.do_hv_on(modules, quabo_uids, quabo_info, detector_info)
-            util.start_hv_updater()
-            time.sleep(5) # Wait for hv_updater to start
+    if stage == 'maroc_config':
+        stage = 'calibrate_ph'
+        print('configuring Marocs')
+        config.do_maroc_config(modules, quabo_uids, quabo_info, data_config, obs_config, daq_config, network_config, True)
 
     if stage == 'mask_config':
         stage = 'maroc_config'
         print('configuring Masks')
-        config.do_mask_config(modules, data_config, True)
-
-    if stage == 'maroc_config':
-        stage = 'calibrate_ph'
-        print('configuring Marocs')
-        config.do_maroc_config(modules, quabo_uids, quabo_info, data_config, obs_config, daq_config, True)
+        config.do_mask_config(modules, data_config, network_config, quabo_uids, True)
     
     if stage == 'calibrate_ph':
         stage = 'open_shutters'
         print('calibrating PH')
-        config.do_calibrate_ph(modules, quabo_uids)
+        config.do_calibrate_ph(modules, quabo_uids, network_config)
         config.do_show_ph_baselines(quabo_uids)
 
-    if stage == 'open_shutters':
-        stage = 'copy_sw'
-        print('opening shutters')
-        config.do_shutter("open")
+    # TODO: we need more tests for do_shutter
+    # if stage == 'open_shutters':
+    #     print('opening shutters')
+    #     config.do_shutter("open")
 
-    if stage == 'copy_sw':
-        print('Copying software to DAQ nodes')
-        file_xfer.copy_daq_files(daq_config)
-
-def print_help():
-    print('Usage: ./session_start.py [--no_hv] [--stage <stage>]')
-    print('  --no_hv: Do not turn on HV.')
-    print('  --stage <stage>: Start the session from the specified stage.')
-    print('    Available stages:')
-    print('      poweron        : Power on the modules. (default stage)')
-    print('      ping           : Wait until all quabos are pingable.')
-    print('      get_uids       : Get quabo UIDs.')
-    print('      reboot         : Reboot quabos.')
-    print('      hk_dest        : Set dest IP for HK packets.')
-    print('      start_redis    : Start Redis daemons.')
-    print('      hv_on          : Turn on HV.')
-    print('      mask_config    : Configure masks.')
-    print('      maroc_config   : Configure Marocs.')
-    print('      calibrate_ph   : Calibrate PH.')
-    print('      open_shutters  : Open the shutters.')
-    print('      copy_sw        : Copy software to DAQ nodes.')
-
-if __name__ == "__main__":
-    def main():
-        # default stage is 'poweron'
-        stage = 'poweron'
-        no_hv = False
-        i = 1
-        argv = sys.argv
-        while i<len(argv):
-            if argv[i] == '--no_hv':
-                no_hv = True
-            elif argv[i] == '--stage':
-                i += 1
-                stage = argv[i]
-            elif argv[i] == '--help' or argv[i] == '-h':
-                print_help()
-                return
-            else:
-                raise Exception('bad arg %s'%argv[i])
-            i += 1
-        
-        # check if obs_comments.txt exists
-        if not os.path.exists('obs_comments.txt'):
-            print('obs_comments.txt not found\n')
-            print('The format of obs_comments.txt is as follows:')
-            print('  line 1         : The name of the observer. (eg. "Wei")')
-            print('  line 2,3,4...  : comments. (eg. "This is a test observation.")')
-            return
-        
-        session_start(
+def main():
+    parser = ArgumentParser(prog=os.path.basename(__file__), allow_abbrev=False)
+    parser.add_argument('--no_hv', dest='no_hv', action='store_true', default=False,
+                        help='Turn off HV when running `start.py`.')
+    parser.add_argument('--stage', dest='stage', type=str, default='poweron', 
+                        choices=['poweron', 'get_uids', 'reboot', 'hk_dest', 'start_redis',
+                                 'maroc_config', 'mask_config', 'calibrate_ph', 'show_ph_baselines'],
+                        help='The session will start from this stage.')
+    # parse the args
+    args = parser.parse_args()
+    # session start
+    session_start(
             config_file.get_obs_config(),
             config_file.get_quabo_info(),
             config_file.get_data_config(),
             config_file.get_daq_config(),
-            no_hv,
-            stage
+            config_file.get_network_config(),
+            args.no_hv,
+            args.stage
         )
-        skymap_helper.start_skymap_info_gen()
+
+if __name__ == "__main__":
     main()

--- a/control/session_start.py
+++ b/control/session_start.py
@@ -14,8 +14,8 @@
 
 import sys, time, os
 
-import config, power, get_uids, util
-from utils import config_file
+import config, power, get_uids
+from utils import config_file, util
 
 from argparse import ArgumentParser
 
@@ -24,7 +24,7 @@ def session_start(obs_config, quabo_info, data_config, daq_config, network_confi
     modules = config_file.get_modules(obs_config)
     # power on the telescopes
     if stage == 'poweron':
-        stage = 'get)uids'
+        stage = 'get_uids'
         power.do_all(obs_config, 'on')
         print('waiting 60 secs for quabos to boot up')
         time.sleep(60)
@@ -32,35 +32,41 @@ def session_start(obs_config, quabo_info, data_config, daq_config, network_confi
     if stage == 'get_uids':
         stage = 'reboot'
         print('getting quabo UIDs')
-        get_uids.get_uids(obs_config)
-        quabo_uids = config_file.get_quabo_uids()
+        get_uids.get_uids(obs_config, network_config)
 
     if stage == 'reboot':
         stage = 'hk_dest'
         modules = config_file.get_modules(obs_config)
         print('rebooting quabos')
+        quabo_uids = config_file.get_quabo_uids()
         status = config.do_reboot(modules, quabo_uids, network_config)
         if status == False:
+            print('Reboot Failed.')
             return
+        else:
+            print('Reboot Successfully.')
 
     if stage == 'hk_dest':
         stage = 'start_redis'
         print('setting hk dest to this computer')
-        config.do_hk_dest(modules, quabo_uids, network_config)
+        quabo_uids = config_file.get_quabo_uids()
+        config.do_hk_dest(modules, quabo_uids, daq_config, network_config)
 
     if stage == 'start_redis':
-        stage = 'hv_on'
+        stage = 'maroc_config'
         print('starting Redis daemons')
         util.start_redis_daemons()
     
     if stage == 'maroc_config':
-        stage = 'calibrate_ph'
+        stage = 'mask_config'
         print('configuring Marocs')
+        quabo_uids = config_file.get_quabo_uids()
         config.do_maroc_config(modules, quabo_uids, quabo_info, data_config, obs_config, daq_config, network_config, True)
 
     if stage == 'mask_config':
-        stage = 'maroc_config'
+        stage = 'calibrate_ph'
         print('configuring Masks')
+        quabo_uids = config_file.get_quabo_uids()
         config.do_mask_config(modules, data_config, network_config, quabo_uids, True)
     
     if stage == 'calibrate_ph':

--- a/control/session_stop.py
+++ b/control/session_stop.py
@@ -3,16 +3,9 @@
 import sys, os
 
 import power
-from tools import skymap_helper
 from utils import config_file, util
 
-def close_domes(obs_config):
-    print('Close the shutters of these domes:')
-    for dome in obs_config['domes']:
-        print('   ', dome['name'])
-
 def session_stop(obs_config):
-    close_domes(obs_config)
     power.do_all(obs_config, 'off')
     try:
         util.stop_redis_daemons()
@@ -21,20 +14,7 @@ def session_stop(obs_config):
               "Try running 'sudo ./config.py --stop_redis_daemons'.")
 
 if __name__ == "__main__":
-    try:
-        os.remove('obs_comments.txt')
-    except:
-        pass
     obs_config = config_file.get_obs_config()
-    daq_config = config_file.get_daq_config()
-    # gen skymap_info.json first, then stop the session
-    skymap_helper.stop_skymap_info_gen()
-    # get run name, and copy the skymap_info.json to the run dir
-    with open('tmp/skymap_info_dir') as f:
-        skymap_info_dir = f.read().strip()
-    run_dir = daq_config['head_node_data_dir'] + '/' + skymap_info_dir
-    print(run_dir)
-    skymap_helper.copy_skymap_info_to_run_dir(run_dir)
     session_stop(obs_config)
     
 


### PR DESCRIPTION
session_start and session_stop tested on the lab system.

## sesstion_start.py
### Stages
session can be started from different stages by using `--stage` option.

The valid stages options are:
* poweron
* get_uids
* reboot
* hk_dest
* start_redis
* maroc_config
* mask_config
* calibrate_ph
* show_ph_baselines

By default, the session starts from `poweron`, then will move to the stages one by one.
If the session starts failed at any stage (for example, it fails at `hk_dest`), you can restart the session from `hk_dest`: `session_start.py --stage hk_dest`.
This saves the time for `poweron`, `get_uids` and `reboot`.
### Output
The same output will be shown on the console:
<img width="310" height="431" alt="image" src="https://github.com/user-attachments/assets/df34f101-8d53-4212-8abc-666ec69f118b" />

### Note
`start.py` is not included.
It could be added, if needed.

## sesstion_stop.py
It will power off the telescopes, and stop redis daemons running on the background.
`stop.py` is also not include.
It could be added, if needed.
