### PR TITLE
fix: syntax bugs and daemons config model

### DIFF
--- a/control/daemons/capture_telemetry_service.py
+++ b/control/daemons/capture_telemetry_service.py
@@ -33,7 +33,7 @@ def main():
     try:
         asyncio.run(serve(
             redis_host=os.getenv("REDIS_HOST", "localhost"),
-            grpc_port=int(os.getenv("GRPC_PORT", 50051)),
+            port=int(os.getenv("GRPC_PORT", 50051)),
             config_path=config_arg
         ))
     except KeyboardInterrupt:

--- a/control/packages/requirements.txt
+++ b/control/packages/requirements.txt
@@ -50,7 +50,7 @@ traitlets==5.9.0
 typing_extensions>=4.5.0
 urllib3==2.0.2
 wcwidth==0.2.6
-zipp==3.15.0
+zipp>=3.15.0
 zope.interface==6.0
 haversine>=2.9.0
 panoseti_grpc>=0.3.5

--- a/control/utils/pydantic_config_models.py
+++ b/control/utils/pydantic_config_models.py
@@ -330,8 +330,10 @@ class NetworkConfigValidator(BaseStrictModel):
 class Daemons(BaseModel):
     model_config = ConfigDict(extra='allow') # Allow dynamic casper_xx keys
 
+
 class DaemonConfigValidator(BaseStrictModel):
     daemons: Daemons
+    permanent_daemons: Daemons
 
 # ------------------------------
 # --- Firmware Config Models ---


### PR DESCRIPTION
Fix minor bugs after the last major merge.

This code has been tested on the obs account on the Headnode, including:

- All essential config.py commands (`redis_daemons`, `stop_redis_daemons`,` maroc_config`, `mask_config`) have been tested.
- The interleave mode and regular daq mode via `start.py` and `stop.py`
- `config.py --validate` also works now.

The data below was collected after these changes:
<img width="6300" height="3600" alt="interleave-test (33)" src="https://github.com/user-attachments/assets/81087035-4949-4ae7-abff-bc3a9232f950" />
<img width="1481" height="785" alt="Capture d’écran 2026-03-11 à 09 53 54" src="https://github.com/user-attachments/assets/f2c67822-c3b8-4c72-85ba-7f1d610f135f" />
