### PR TITLE
Use a loop for the HV control

### DIFF
--- a/control/daemons/capture_hk/panosetiSIconvert.py
+++ b/control/daemons/capture_hk/panosetiSIconvert.py
@@ -30,13 +30,13 @@ class HKconvert():
         self.currentFactor = 1e9
         
     def HVMON(self, value):
-        return -value*1.22*1e6 / self.voltageFactor
+        return -value*1.209361*1e6 / self.voltageFactor
 
     def HVIMON(self, value):
         return (65535-value)*38.1 / self.currentFactor
 
     def RAWHVMON(self, value):
-        return -value*1.22*1e6 / self.voltageFactor
+        return -value*1.209361*1e6 / self.voltageFactor
 
     def V12MON(self, value):
         return value*19.07*1e3 / self.voltageFactor

--- a/control/tools/hv_updater.py
+++ b/control/tools/hv_updater.py
@@ -29,7 +29,11 @@ UPDATE_INTERVAL = 5
 # Min & max detector operating temperatures (degrees Celsius).
 MIN_TEMP = -20.0
 MAX_TEMP = 60.0
-
+# Min & max hv.
+MIN_HV = 50
+MAX_HV = 60
+# we don't use the loop to set up the HV the first time.
+INIT_SET = True
 #--------- Implementation Globals --------#
 
 # Get quabo and detector info.
@@ -46,6 +50,15 @@ def is_acceptable_temperature(temp: float):
     MIN_TEMP and MAX_TEMP."""
     return MIN_TEMP <= temp <= MAX_TEMP
 
+def is_acceptable_hv(monitored_hv: list):
+    """Returns True only if the provided hv is reasonable. """
+    r = True
+    for hv in monitored_hv:
+        if MIN_HV <= hv <= MAX_HV:
+            r = True
+        else:
+            r = False
+    return r
 
 def get_adjusted_detector_hv(det_serial_num: str, temp: float) -> float:
     """Given a detector serial number and a temperature in degrees Celsius,
@@ -67,7 +80,8 @@ def get_adjusted_detector_hv(det_serial_num: str, temp: float) -> float:
 
 def update_quabo(quabo_obj: quabo_driver.QUABO,
                  det_serial_nums: list,
-                 temp: float):
+                 temp: float,
+                 monitored_hv: list):
     """Helper method for the function update_all_quabos. Updates each
      detector in the quabo represented by quabo_obj."""
     logger = logging.getLogger('PANOSETI.HVUpdater')
@@ -75,7 +89,18 @@ def update_quabo(quabo_obj: quabo_driver.QUABO,
     try:
         for detector_index in range(4):
             det_serial_num = det_serial_nums[detector_index]
-            adjusted_hv = get_adjusted_detector_hv(det_serial_num, temp)
+            target_hv = get_adjusted_detector_hv(det_serial_num, temp)
+            if INIT_SET:
+                # When we set HV the first time, we don't use the loop
+                adjusted_hv = target_hv
+                INIT_SET = False
+                logger.debug('Init HV setting.')
+            else:
+                # Now, we start to use the loop the set the HV
+                adjusted_hv = target_hv + (target_hv - monitored_hv[detector_index])*0.5
+            logger.debug(f'Target HV{detector_index}: -{target_hv}V')
+            logger.debug(f'Monitored HV{detector_index}: -{monitored_hv[detector_index]}V')
+            logger.debug(f'Adjusted HV{detector_index}: -{adjusted_hv}V')
             # Save int encoding
             #adjusted_hv_values[detector_index] = int((adjusted_hv + HV_OFFSET) / 0.0011453)
             adjusted_hv_values[detector_index] = int((adjusted_hv) / 0.0011324717)
@@ -97,13 +122,32 @@ def get_redis_temp(r: redis.Redis, rkey: str) -> float:
     except redis.RedisError as err:
         msg = "hv_updater: A Redis error occurred. "
         msg += "Error msg: {0}"
+        logger.err(msg.format(err))
         raise
     except TypeError as terr:
         msg = "hv_updater: Failed to update '{0}'. "
         msg += "Temperature HK data may be missing. "
         msg += "Error msg: {1}"
+        logger.err(msg.format(rkey, terr))
         raise
 
+def get_redis_hv(r: redis.Redis, rkey: str, q: int) -> float:
+    """Given a Quabo's redis key, rkey, returns the field value of HVMON{q} in Redis."""
+    logger = logging.getLogger('PANOSETI.HVUpdater')
+    try:
+        hv = float(r.hget(rkey, f'HVMON{q}'))
+        return hv
+    except redis.RedisError as err:
+        msg = "hv_updater: A Redis error occurred. "
+        msg += "Error msg: {0}"
+        logger.err(msg.format(err))
+        raise
+    except TypeError as terr:
+        msg = "hv_updater: Failed to update '{0}'. "
+        msg += f"HV{q} HK data may be missing. "
+        msg += "Error msg: {1}"
+        logger.err(msg.format(rkey, terr))
+        raise
 
 def update_all_quabos(r: redis.Redis):
     """Iterates through each quabo in the observatory and updates
@@ -129,6 +173,11 @@ def update_all_quabos(r: redis.Redis):
                     else:
                         # Get the temperature data for this quabo.
                         temp = get_redis_temp(r, rkey)
+                        # Get the monitored HV
+                        monitored_hv = []
+                        for i in range(4):
+                            mhv = get_redis_hv(r, rkey, i)
+                            monitored_hv.append(mhv)
                     # Get quabo object
                     q_ip_addr = config_file.quabo_ip_addr(module_ip_addr, quabo_index)
                     logger.debug('Quabo IP: %s'%q_ip_addr)
@@ -166,8 +215,8 @@ def update_all_quabos(r: redis.Redis):
                 else:
                     # Checks whether the quabo temperature is acceptable.
                     # See https://github.com/panoseti/panoseti/issues/58.
-                    if is_acceptable_temperature(temp):
-                        update_quabo(quabo_obj, detector_serial_nums, temp)
+                    if is_acceptable_temperature(temp) and is_acceptable_hv(monitored_hv):
+                        update_quabo(quabo_obj, detector_serial_nums, temp, monitored_hv)
                     else:
                         msg = "hv_updater: The temperature of quabo {0} with base IP {1} is {2} C, "
                         msg += "which exceeds the maximum operating temperatures. \n"
@@ -186,7 +235,6 @@ def update_all_quabos(r: redis.Redis):
                 finally:
                     if quabo_obj is not None:
                         quabo_obj.close()
-
 
 def main():
     """Makes a call to update_all_quabos every UPDATE_INTERVAL seconds."""

--- a/control/tools/hv_updater.py
+++ b/control/tools/hv_updater.py
@@ -32,12 +32,7 @@ MAX_TEMP = 60.0
 # Min & max hv.
 MIN_HV = 0
 MAX_HV = 60
-# we don't use the loop to set up the HV the first time.
-INIT_SET = True
 
-# global vars for recording the previous data
-adjusted_hv = [0] * 4
-timestamp_pre = 0
 #--------- Implementation Globals --------#
 
 # Get quabo and detector info.
@@ -83,23 +78,28 @@ def get_adjusted_detector_hv(det_serial_num: str, temp: float) -> float:
 
 
 def update_quabo(quabo_obj: quabo_driver.QUABO,
-                 det_serial_nums: list,
-                 temp: float,
-                 monitored_hv: list):
+                 rkey: str,
+                 quabo_status: dict
+                ):
     """Helper method for the function update_all_quabos. Updates each
      detector in the quabo represented by quabo_obj."""
     logger = logging.getLogger('PANOSETI.HVUpdater')
     adjusted_hv_values = [0] * 4
-    global adjusted_hv
+    # get the metadata from the quabo_status dict
+    adjusted_hv = quabo_status[rkey]['adjusted_hv']
+    temp = quabo_status[rkey]['temp']
+    det_serial_nums = quabo_status[rkey]['detector_serial_nums']
+    monitored_hv = quabo_status[rkey]['monitored_hv']
+    init_set = quabo_status[rkey]['init_set']
     try:
-        global INIT_SET
+        logger.debug(f'           Temp: {temp:.02f}')
         for detector_index in range(4):
             det_serial_num = det_serial_nums[detector_index]
             target_hv = get_adjusted_detector_hv(det_serial_num, temp)
-            if INIT_SET:
+            if init_set:
                 # When we set HV the first time, we don't use the loop
                 adjusted_hv[detector_index] = target_hv
-                logger.debug('Init HV setting.')
+                logger.debug(f'{rkey} Init HV setting.')
             else:
                 # Now, we start to use the loop the set the HV
                 adjusted_hv[detector_index] = adjusted_hv[detector_index] + (target_hv - monitored_hv[detector_index])*0.5
@@ -107,12 +107,13 @@ def update_quabo(quabo_obj: quabo_driver.QUABO,
                 if adjusted_hv[detector_index] >= MAX_HV:
                     adjusted_hv[detector_index] = MAX_HV
                 #adjusted_hv = target_hv
-            logger.debug(f'Target HV{detector_index}: -{target_hv}V')
-            logger.debug(f'Monitored HV{detector_index}: -{monitored_hv[detector_index]}V')
-            logger.debug(f'Adjusted HV{detector_index}: -{adjusted_hv[detector_index]}V')
+            logger.debug(f'     Target HV{detector_index}: -{target_hv:.3f}V')
+            logger.debug(f'  Monitored HV{detector_index}: -{monitored_hv[detector_index]:.3f}V')
+            logger.debug(f'   Adjusted HV{detector_index}: -{adjusted_hv[detector_index]:.3f}V')
             # Save int encoding
-            #adjusted_hv_values[detector_index] = int((adjusted_hv + HV_OFFSET) / 0.0011453)
+            #adjusted_hv_values[detector_index] = int((adjusted_hv[detector_index] + HV_OFFSET) / 0.0011453)
             adjusted_hv_values[detector_index] = int((adjusted_hv[detector_index]) / 0.0011324717)
+        logger.debug(' ')
     except KeyError as kerr:
         msg = "A detector in the quabo with IP {0} could not be found in the configuration files. "
         msg += "Error message: {1}"
@@ -120,9 +121,9 @@ def update_quabo(quabo_obj: quabo_driver.QUABO,
         raise
     else:
         quabo_obj.hv_set(adjusted_hv_values)
-        if INIT_SET:
+        if init_set:
             time.sleep(5)
-            INIT_SET = False
+            quabo_status[rkey]['init_set'] = False
 
 
 def get_redis_temp(r: redis.Redis, rkey: str) -> float:
@@ -161,18 +162,17 @@ def get_redis_hv(r: redis.Redis, rkey: str, q: int) -> float:
         logger.err(msg.format(rkey, terr))
         raise
 
-def check_timestamp(r: redis.Redis, rkey: str):
+def check_timestamp(r: redis.Redis, rkey: str, quabo_status: dict):
     """
         check the timestamp in the redis database.
         if the timestamp doesn't change, return false
     """
     logger = logging.getLogger('PANOSETI.HVUpdater')
-    global timestamp_pre
     try:
         timestamp = float(r.hget(rkey, 'Computer_UTC'))
-        if timestamp - timestamp_pre > 0.1 :
+        if timestamp - quabo_status[rkey]['timestamp_pre'] > 0.1 :
             # check the timestamp difference, to make sure the hk data is updated
-            timestamp_pre = timestamp
+            quabo_status[rkey]['timestamp_pre'] = timestamp
             return True
         else:
             return False
@@ -182,7 +182,19 @@ def check_timestamp(r: redis.Redis, rkey: str):
         logger.err(msg.format(err))
         raise
 
-def update_all_quabos(r: redis.Redis):
+def init_quabo_status(rkey: str, quabo_status: dict):
+    """init the quabo info for the specific Quabo. """
+    quabo_status[rkey] = {
+        'init_set' : True,
+        'timestamp_pre' : 0,
+        'detector_serial_nums' : [0, 0, 0, 0],
+        'temp' : 0,
+        'monitored_hv' : [0, 0, 0, 0],
+        'monitored_hvi' : [0, 0, 0, 0],
+        'adjusted_hv' : [0, 0, 0, 0]
+    }
+
+def update_all_quabos(r: redis.Redis, quabo_status: dict):
     """Iterates through each quabo in the observatory and updates
     its detectors' high-voltage values, provided its temperature is
     not too extreme."""
@@ -195,12 +207,16 @@ def update_all_quabos(r: redis.Redis):
                 try:
                     # Get this Quabo's redis key.
                     rkey = "QUABO_{0}".format(config_file.get_boardloc(module_ip_addr, quabo_index))
+                    # check if we already have records for this Quabo
+                    if rkey not in quabo_status:
+                        # if not, we need to create a new record for this Quabo
+                        init_quabo_status(rkey, quabo_status)
                     if rkey in quabos_off:
                         continue
                     uid = module['quabos'][quabo_index]['uid']
                     if uid == '':
                         continue
-                    if not check_timestamp(r, rkey):
+                    if not check_timestamp(r, rkey, quabo_status):
                         logger.warning("Housekeeping data hasn't been updated.")
                         continue
                     # Get this Quabo's temp, if it exists.
@@ -209,20 +225,21 @@ def update_all_quabos(r: redis.Redis):
                     else:
                         # Get the temperature data for this quabo.
                         temp = get_redis_temp(r, rkey)
+                        quabo_status[rkey]['temp'] = temp
                         # Get the monitored HV
                         monitored_hv = []
                         for i in range(4):
                             mhv = get_redis_hv(r, rkey, i)
                             monitored_hv.append(mhv)
+                        quabo_status[rkey]['monitored_hv'] = monitored_hv
+                        # TODO: add monitored_hvi
                     # Get quabo object
                     q_ip_addr = config_file.quabo_ip_addr(module_ip_addr, quabo_index)
-                    logger.debug('Quabo IP: %s'%q_ip_addr)
-                    logger.debug('Temp: %.02f'%temp)
                     ip_port = util.get_quabo_ip_port(module_ip_addr, quabo_index, network_config)
                     real_ip = ip_port['ip_addr']
                     port = ip_port['cmd_port']
-                    logger.debug('Real IP: %s'%real_ip)
-                    logger.debug('CMD port: %d'%port)
+                    logger.debug(f'{rkey}({q_ip_addr}):')
+                    logger.debug(f'Port forwarding: {real_ip}:{port}')
                     quabo_obj = quabo_driver.QUABO(real_ip, port)
                     # Get the list of detector serial numbers for this quabo.
                     try:
@@ -231,6 +248,8 @@ def update_all_quabos(r: redis.Redis):
                         q_info = quabo_info['default']
                         logger.warning('No calibration data: UID - %s'%uid)
                     detector_serial_nums = [s for s in q_info['detector_serialno']]
+                    # record the detector_serial_nums in the quabo_status dict
+                    quabo_status[rkey]['detector_serial_nums'] = detector_serial_nums
                 except Warning as werr:
                     msg = "hv_updater: Failed to update quabo at index {0} with base IP {1}. "
                     msg += "Error msg: {2} \n"
@@ -253,7 +272,7 @@ def update_all_quabos(r: redis.Redis):
                     # See https://github.com/panoseti/panoseti/issues/58.
                     #if is_acceptable_temperature(temp) and is_acceptable_hv(monitored_hv):
                     if is_acceptable_temperature(temp):
-                        update_quabo(quabo_obj, detector_serial_nums, temp, monitored_hv)
+                        update_quabo(quabo_obj, rkey, quabo_status)
                     else:
                         msg = "hv_updater: The temperature of quabo {0} with base IP {1} is {2} C, "
                         msg += "which exceeds the maximum operating temperatures. \n"
@@ -277,8 +296,19 @@ def main():
     """Makes a call to update_all_quabos every UPDATE_INTERVAL seconds."""
     r = redis_utils.redis_init()
     print("hv_updater: Running...")
+    """
+    The dict is used for recording all of the hv status data for each quabo
+    It contains the following info:
+    1. temp - temperature;
+    2. timestamp_pre - the previous timestamp for the Quabo;
+    3. init_set - it shows if the init setting is done;
+    4. monitored_hv - this is a list, which records the monitored 4 hv on the quabo;
+    5. monitored_hvi - this is a list, which records the monitored 4 hv  current on the quabo;
+    5. adjusted_hv - this is a list, which records the latest 4 hv on the quabo.
+    """
+    quabo_status = {}
     while True:
-        update_all_quabos(r)
+        update_all_quabos(r, quabo_status)
         time.sleep(UPDATE_INTERVAL)
 
 

--- a/control/tools/hv_updater.py
+++ b/control/tools/hv_updater.py
@@ -98,7 +98,7 @@ def update_quabo(quabo_obj: quabo_driver.QUABO,
             det_serial_num = det_serial_nums[detector_index]
             # compensate for current limitter(LND150) voltage drop
             # the typical resistance of LND150 is 850 ohm
-            target_hv = get_adjusted_detector_hv(det_serial_num, temp) + monitored_det_cur[detector_index] * 850
+            target_hv = get_adjusted_detector_hv(det_serial_num, temp) + monitored_det_cur[detector_index] * 850/4
             if init_set:
                 # When we set HV the first time, we don't use the loop
                 adjusted_hv[detector_index] = target_hv

--- a/control/tools/hv_updater.py
+++ b/control/tools/hv_updater.py
@@ -30,10 +30,11 @@ UPDATE_INTERVAL = 5
 MIN_TEMP = -20.0
 MAX_TEMP = 60.0
 # Min & max hv.
-MIN_HV = 50
+MIN_HV = 0
 MAX_HV = 60
 # we don't use the loop to set up the HV the first time.
 INIT_SET = True
+adjusted_hv = [0] * 4
 #--------- Implementation Globals --------#
 
 # Get quabo and detector info.
@@ -86,24 +87,26 @@ def update_quabo(quabo_obj: quabo_driver.QUABO,
      detector in the quabo represented by quabo_obj."""
     logger = logging.getLogger('PANOSETI.HVUpdater')
     adjusted_hv_values = [0] * 4
+    global adjusted_hv
     try:
+        global INIT_SET
         for detector_index in range(4):
             det_serial_num = det_serial_nums[detector_index]
             target_hv = get_adjusted_detector_hv(det_serial_num, temp)
             if INIT_SET:
                 # When we set HV the first time, we don't use the loop
-                adjusted_hv = target_hv
-                INIT_SET = False
+                adjusted_hv[detector_index] = target_hv
                 logger.debug('Init HV setting.')
             else:
                 # Now, we start to use the loop the set the HV
-                adjusted_hv = target_hv + (target_hv - monitored_hv[detector_index])*0.5
+                adjusted_hv[detector_index] = adjusted_hv[detector_index] + (target_hv - monitored_hv[detector_index])*0.5
+                #adjusted_hv = target_hv
             logger.debug(f'Target HV{detector_index}: -{target_hv}V')
             logger.debug(f'Monitored HV{detector_index}: -{monitored_hv[detector_index]}V')
-            logger.debug(f'Adjusted HV{detector_index}: -{adjusted_hv}V')
+            logger.debug(f'Adjusted HV{detector_index}: -{adjusted_hv[detector_index]}V')
             # Save int encoding
             #adjusted_hv_values[detector_index] = int((adjusted_hv + HV_OFFSET) / 0.0011453)
-            adjusted_hv_values[detector_index] = int((adjusted_hv) / 0.0011324717)
+            adjusted_hv_values[detector_index] = int((adjusted_hv[detector_index]) / 0.0011324717)
     except KeyError as kerr:
         msg = "A detector in the quabo with IP {0} could not be found in the configuration files. "
         msg += "Error message: {1}"
@@ -111,6 +114,9 @@ def update_quabo(quabo_obj: quabo_driver.QUABO,
         raise
     else:
         quabo_obj.hv_set(adjusted_hv_values)
+        if INIT_SET:
+            time.sleep(5)
+            INIT_SET = False
 
 
 def get_redis_temp(r: redis.Redis, rkey: str) -> float:
@@ -135,7 +141,7 @@ def get_redis_hv(r: redis.Redis, rkey: str, q: int) -> float:
     """Given a Quabo's redis key, rkey, returns the field value of HVMON{q} in Redis."""
     logger = logging.getLogger('PANOSETI.HVUpdater')
     try:
-        hv = float(r.hget(rkey, f'HVMON{q}'))
+        hv = float(r.hget(rkey, f'HVMON{q}')) * -1
         return hv
     except redis.RedisError as err:
         msg = "hv_updater: A Redis error occurred. "
@@ -215,7 +221,8 @@ def update_all_quabos(r: redis.Redis):
                 else:
                     # Checks whether the quabo temperature is acceptable.
                     # See https://github.com/panoseti/panoseti/issues/58.
-                    if is_acceptable_temperature(temp) and is_acceptable_hv(monitored_hv):
+                    #if is_acceptable_temperature(temp) and is_acceptable_hv(monitored_hv):
+                    if is_acceptable_temperature(temp):
                         update_quabo(quabo_obj, detector_serial_nums, temp, monitored_hv)
                     else:
                         msg = "hv_updater: The temperature of quabo {0} with base IP {1} is {2} C, "

--- a/control/tools/hv_updater.py
+++ b/control/tools/hv_updater.py
@@ -90,12 +90,15 @@ def update_quabo(quabo_obj: quabo_driver.QUABO,
     temp = quabo_status[rkey]['temp']
     det_serial_nums = quabo_status[rkey]['detector_serial_nums']
     monitored_hv = quabo_status[rkey]['monitored_hv']
+    monitored_det_cur = quabo_status[rkey]['monitored_det_cur']
     init_set = quabo_status[rkey]['init_set']
     try:
         logger.debug(f'           Temp: {temp:.02f}')
         for detector_index in range(4):
             det_serial_num = det_serial_nums[detector_index]
-            target_hv = get_adjusted_detector_hv(det_serial_num, temp)
+            # compensate for current limitter(LND150) voltage drop
+            # the typical resistance of LND150 is 850 ohm
+            target_hv = get_adjusted_detector_hv(det_serial_num, temp) + monitored_det_cur[detector_index] * 850
             if init_set:
                 # When we set HV the first time, we don't use the loop
                 adjusted_hv[detector_index] = target_hv
@@ -109,11 +112,12 @@ def update_quabo(quabo_obj: quabo_driver.QUABO,
                 #adjusted_hv = target_hv
             logger.debug(f'     Target HV{detector_index}: -{target_hv:.3f}V')
             logger.debug(f'  Monitored HV{detector_index}: -{monitored_hv[detector_index]:.3f}V')
+            logger.debug(f'  Detector Cur{detector_index}:  {monitored_det_cur[detector_index]*1000:.3f}mA')
             logger.debug(f'   Adjusted HV{detector_index}: -{adjusted_hv[detector_index]:.3f}V')
+            logger.debug(' ')
             # Save int encoding
-            #adjusted_hv_values[detector_index] = int((adjusted_hv[detector_index] + HV_OFFSET) / 0.0011453)
-            adjusted_hv_values[detector_index] = int((adjusted_hv[detector_index]) / 0.0011324717)
-        logger.debug(' ')
+            adjusted_hv_values[detector_index] = int((adjusted_hv[detector_index] + HV_OFFSET) / 0.0011453)
+            #adjusted_hv_values[detector_index] = int((adjusted_hv[detector_index]) / 0.0011324717)
     except KeyError as kerr:
         msg = "A detector in the quabo with IP {0} could not be found in the configuration files. "
         msg += "Error message: {1}"
@@ -162,6 +166,24 @@ def get_redis_hv(r: redis.Redis, rkey: str, q: int) -> float:
         logger.err(msg.format(rkey, terr))
         raise
 
+def get_redis_det_current(r: redis.Redis, rkey: str, q: int) -> float:
+    """Given a Quabo's redis key, rkey, returns the field value of DETR{q}_CURR in Redis."""
+    logger = logging.getLogger('PANOSETI.HVUpdater')
+    try:
+        det_cur = float(r.hget(rkey, f'DETR{q}_CURR'))
+        return det_cur
+    except redis.RedisError as err:
+        msg = "hv_updater: A Redis error occurred. "
+        msg += "Error msg: {0}"
+        logger.err(msg.format(err))
+        raise
+    except TypeError as terr:
+        msg = "hv_updater: Failed to update '{0}'. "
+        msg += f"HV{q} HK data may be missing. "
+        msg += "Error msg: {1}"
+        logger.err(msg.format(rkey, terr))
+        raise
+
 def check_timestamp(r: redis.Redis, rkey: str, quabo_status: dict):
     """
         check the timestamp in the redis database.
@@ -190,8 +212,8 @@ def init_quabo_status(rkey: str, quabo_status: dict):
         'detector_serial_nums' : [0, 0, 0, 0],
         'temp' : 0,
         'monitored_hv' : [0, 0, 0, 0],
-        'monitored_hvi' : [0, 0, 0, 0],
-        'adjusted_hv' : [0, 0, 0, 0]
+        'monitored_det_cur' : [0, 0, 0, 0],
+        'adjusted_hv' : [0, 0, 0, 0],
     }
 
 def update_all_quabos(r: redis.Redis, quabo_status: dict):
@@ -232,12 +254,18 @@ def update_all_quabos(r: redis.Redis, quabo_status: dict):
                             mhv = get_redis_hv(r, rkey, i)
                             monitored_hv.append(mhv)
                         quabo_status[rkey]['monitored_hv'] = monitored_hv
-                        # TODO: add monitored_hvi
+                        # Get the monitored detector current
+                        monitored_det_cur = []
+                        for i in range(4):
+                            mdetcur = get_redis_det_current(r, rkey, i)
+                            monitored_det_cur.append(mdetcur)
+                        quabo_status[rkey]['monitored_det_cur'] = monitored_det_cur
                     # Get quabo object
                     q_ip_addr = config_file.quabo_ip_addr(module_ip_addr, quabo_index)
                     ip_port = util.get_quabo_ip_port(module_ip_addr, quabo_index, network_config)
                     real_ip = ip_port['ip_addr']
                     port = ip_port['cmd_port']
+                    logger.debug(f'-------------------------')
                     logger.debug(f'{rkey}({q_ip_addr}):')
                     logger.debug(f'Port forwarding: {real_ip}:{port}')
                     quabo_obj = quabo_driver.QUABO(real_ip, port)

--- a/control/tools/hv_updater.py
+++ b/control/tools/hv_updater.py
@@ -24,7 +24,7 @@ import logging
 HV_OFFSET = 1.073
 
 # Seconds between updates.
-UPDATE_INTERVAL = 5
+UPDATE_INTERVAL = 3
 
 # Min & max detector operating temperatures (degrees Celsius).
 MIN_TEMP = -20.0
@@ -34,7 +34,10 @@ MIN_HV = 0
 MAX_HV = 60
 # we don't use the loop to set up the HV the first time.
 INIT_SET = True
+
+# global vars for recording the previous data
 adjusted_hv = [0] * 4
+timestamp_pre = 0
 #--------- Implementation Globals --------#
 
 # Get quabo and detector info.
@@ -100,6 +103,9 @@ def update_quabo(quabo_obj: quabo_driver.QUABO,
             else:
                 # Now, we start to use the loop the set the HV
                 adjusted_hv[detector_index] = adjusted_hv[detector_index] + (target_hv - monitored_hv[detector_index])*0.5
+                # make sure the adjusted_hv is a reasonable value
+                if adjusted_hv[detector_index] >= MAX_HV:
+                    adjusted_hv[detector_index] = MAX_HV
                 #adjusted_hv = target_hv
             logger.debug(f'Target HV{detector_index}: -{target_hv}V')
             logger.debug(f'Monitored HV{detector_index}: -{monitored_hv[detector_index]}V')
@@ -155,6 +161,27 @@ def get_redis_hv(r: redis.Redis, rkey: str, q: int) -> float:
         logger.err(msg.format(rkey, terr))
         raise
 
+def check_timestamp(r: redis.Redis, rkey: str):
+    """
+        check the timestamp in the redis database.
+        if the timestamp doesn't change, return false
+    """
+    logger = logging.getLogger('PANOSETI.HVUpdater')
+    global timestamp_pre
+    try:
+        timestamp = float(r.hget(rkey, 'Computer_UTC'))
+        if timestamp - timestamp_pre > 0.1 :
+            # check the timestamp difference, to make sure the hk data is updated
+            timestamp_pre = timestamp
+            return True
+        else:
+            return False
+    except redis.RedisError as err:
+        msg = "hv_updater: A Redis error occurred. "
+        msg += "Error msg: {0}"
+        logger.err(msg.format(err))
+        raise
+
 def update_all_quabos(r: redis.Redis):
     """Iterates through each quabo in the observatory and updates
     its detectors' high-voltage values, provided its temperature is
@@ -172,6 +199,9 @@ def update_all_quabos(r: redis.Redis):
                         continue
                     uid = module['quabos'][quabo_index]['uid']
                     if uid == '':
+                        continue
+                    if not check_timestamp(r, rkey):
+                        logger.warning("Housekeeping data hasn't been updated.")
                         continue
                     # Get this Quabo's temp, if it exists.
                     if rkey.encode('utf-8') not in r.keys():


### PR DESCRIPTION
We use a loop for the HV control, which works as below:
<img width="400" height="700" alt="image" src="https://github.com/user-attachments/assets/02745b95-bd2e-4a15-bc26-2a741040afc2" />

We did tests on the Fern and PTI telescopes at Palomar, and here is an example about the test results:
<img width="2534" height="883" alt="image" src="https://github.com/user-attachments/assets/60c91c6e-7995-4a2c-a98a-801254ff8bc9" />

When we opened the dome at ~9:00pm, the temperature went up a lot at that moment, which caused a big HV drop.
Then, the loop compensated for that drop, so the HV went back to the original value.

 