### PR TITLE
Add xfr clean, --non-interactive maroc-config, and misc fixes

### DIFF
--- a/control/CLI.md
+++ b/control/CLI.md
@@ -52,7 +52,8 @@ Control Quabo power via Web Power Switches (WPS). By default, queries the status
 Fetch quabo IP addrs based on the current `obs_config.json` to get UIDs.
 
 ### `pseti xfr`
-Manage the background file transfer queue. Supports `stat`, `queue`, `retry`, `tail`, `verify`, and `start`/`stop` for the daemon.
+Manage the background file transfer queue. Supports `stat`, `queue`, `retry`, `delete`, `tail`, `verify`, and `start`/`stop` for the daemon.
+- `delete <run_name>`: Remove a job from `pending/` so the daemon skips it — no data is copied from the DAQ node for that run.
 
 ### `pseti session-start`
 Initialize hardware, power, and calibration for an observing session.

--- a/control/CLI.md
+++ b/control/CLI.md
@@ -52,8 +52,8 @@ Control Quabo power via Web Power Switches (WPS). By default, queries the status
 Fetch quabo IP addrs based on the current `obs_config.json` to get UIDs.
 
 ### `pseti xfr`
-Manage the background file transfer queue. Supports `stat`, `queue`, `retry`, `delete`, `tail`, `verify`, and `start`/`stop` for the daemon.
-- `delete <run_name>`: Remove a job from `pending/` so the daemon skips it — no data is copied from the DAQ node for that run.
+Manage the background file transfer queue. Supports `stat`, `queue`, `retry`, `clean`, `tail`, `verify`, and `start`/`stop` for the daemon.
+- `clean <run_name>`: Remove a job from `pending/` so the daemon skips it — no data is copied from the DAQ node for that run.
 
 ### `pseti session-start`
 Initialize hardware, power, and calibration for an observing session.

--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pseti-ctl"
-version = "0.1.1"
+version = "0.1.2"
 description = "PANOSETI observatory instrument control system"
 requires-python = ">=3.14"
 dependencies = [

--- a/control/src/ci/software_only/tier1_unit/test_transfer_queue.py
+++ b/control/src/ci/software_only/tier1_unit/test_transfer_queue.py
@@ -190,25 +190,27 @@ class TestRetry:
         assert tq.retry("no_such_run") is False
 
 
-class TestDelete:
-    def test_delete_removes_pending(self, tq: TransferQueue) -> None:
-        """delete() must remove the job file from pending/."""
+class TestClean:
+    def test_clean_removes_pending(self, tq: TransferQueue) -> None:
+        """clean() must remove the job file from pending/."""
         tq.enqueue(_make_job("run_010"))
 
-        assert tq.delete("run_010") is True
+        removed = tq.clean("run_010")
+        assert removed is not None
+        assert removed.run_name == "run_010"
         assert not (tq._queue / "pending" / "run_010.job.toml").exists()
 
-    def test_delete_nonexistent_returns_false(self, tq: TransferQueue) -> None:
-        """delete() returns False if the run name is not in pending/."""
-        assert tq.delete("no_such_run") is False
+    def test_clean_nonexistent_returns_none(self, tq: TransferQueue) -> None:
+        """clean() returns None if the run name is not in pending/."""
+        assert tq.clean("no_such_run") is None
 
-    def test_delete_does_not_touch_active(self, tq: TransferQueue) -> None:
-        """delete() must not remove a job that's already been claimed into active/."""
+    def test_clean_does_not_touch_active(self, tq: TransferQueue) -> None:
+        """clean() must not remove a job that's already been claimed into active/."""
         tq.enqueue(_make_job("run_011"))
         job = tq.claim()
         assert job is not None
 
-        assert tq.delete("run_011") is False
+        assert tq.clean("run_011") is None
         assert (tq._queue / "active" / "run_011.job.toml").exists()
 
 

--- a/control/src/ci/software_only/tier1_unit/test_transfer_queue.py
+++ b/control/src/ci/software_only/tier1_unit/test_transfer_queue.py
@@ -190,6 +190,28 @@ class TestRetry:
         assert tq.retry("no_such_run") is False
 
 
+class TestDelete:
+    def test_delete_removes_pending(self, tq: TransferQueue) -> None:
+        """delete() must remove the job file from pending/."""
+        tq.enqueue(_make_job("run_010"))
+
+        assert tq.delete("run_010") is True
+        assert not (tq._queue / "pending" / "run_010.job.toml").exists()
+
+    def test_delete_nonexistent_returns_false(self, tq: TransferQueue) -> None:
+        """delete() returns False if the run name is not in pending/."""
+        assert tq.delete("no_such_run") is False
+
+    def test_delete_does_not_touch_active(self, tq: TransferQueue) -> None:
+        """delete() must not remove a job that's already been claimed into active/."""
+        tq.enqueue(_make_job("run_011"))
+        job = tq.claim()
+        assert job is not None
+
+        assert tq.delete("run_011") is False
+        assert (tq._queue / "active" / "run_011.job.toml").exists()
+
+
 class TestListJobs:
     def test_list_jobs_pending(self, tq: TransferQueue) -> None:
         """list_jobs('pending') must return all enqueued run names."""

--- a/control/src/control/admin/cli.py
+++ b/control/src/control/admin/cli.py
@@ -867,19 +867,39 @@ def status(
             env = _daq_compose_env()
             project_name = f"pseti-daqnode-{host.replace('.', '-')}"
 
+            # `docker compose ps -p <project>` lists every container Docker has
+            # labeled with that project name, regardless of which -f file is
+            # passed -- daqnode-server and alloy are deployed under the same
+            # project_name (see deploy_node()), so a single call already shows
+            # both. A second call against docker-compose.alloy.yml used to be
+            # made here purely to print a separate "Alloy Status:" header, but
+            # it returned the exact same container list and additionally
+            # triggered a WARN[0000] from compose trying to interpolate that
+            # file's ${HOSTNAME} (which is never in _ENV_FILE_KEYS).
             compose_file = PanoPaths.software_root_dir() / "grpc" / "deploy" / "docker-compose.daqnode.yml"
             cmd = [*_compose_prefix(context, project_name, compose_file, env), "ps"]
             console.print(f"[[bold cyan]{host}[/bold cyan]] DAQ Node Status:")
             run_cmd(host, cmd, env=env, quiet=True)
 
-            from control.utils.config_file import get_daq_config
-            from control.utils.util import is_local
-            is_headnode = is_local(host, get_daq_config())
-            if not is_headnode:
-                alloy_compose_file = PanoPaths.software_root_dir() / "grpc" / "deploy" / "alloy" / "docker-compose.alloy.yml"
-                alloy_cmd = [*_compose_prefix(context, project_name, alloy_compose_file, env), "ps"]
-                console.print(f"[[bold cyan]{host}[/bold cyan]] Alloy Status:")
-                run_cmd(host, alloy_cmd, env=env, quiet=True)
+            # Commented out (not deleted): this used to be a second, separate
+            # `docker compose ps` call scoped to docker-compose.alloy.yml just
+            # to print an "Alloy Status:" header. It's redundant -- `ps -p
+            # <project>` above already returns every container under that
+            # project name (daqnode-server AND alloy, since deploy_node()
+            # deploys both under the same project_name), so this block only
+            # ever reprinted the identical table a second time, and also
+            # triggered a spurious WARN[0000] from compose trying to
+            # interpolate this file's ${HOSTNAME} (never set via --env-file,
+            # see _ENV_FILE_KEYS). Kept here in case Alloy is ever deployed
+            # under its own distinct project name in the future.
+            # from control.utils.config_file import get_daq_config
+            # from control.utils.util import is_local
+            # is_headnode = is_local(host, get_daq_config())
+            # if not is_headnode:
+            #     alloy_compose_file = PanoPaths.software_root_dir() / "grpc" / "deploy" / "alloy" / "docker-compose.alloy.yml"
+            #     alloy_cmd = [*_compose_prefix(context, project_name, alloy_compose_file, env), "ps"]
+            #     console.print(f"[[bold cyan]{host}[/bold cyan]] Alloy Status:")
+            #     run_cmd(host, alloy_cmd, env=env, quiet=True)
         else:
             ssh_target = _resolve_bare_metal_ssh_target(host)
             remote_check = "systemctl is-active panoseti_grpc panoseti_alloy"

--- a/control/src/control/config.py
+++ b/control/src/control/config.py
@@ -1191,7 +1191,11 @@ def hv_off() -> None:
     do_hv_off(modules, quabo_uids, network_config)
 
 @app.command()
-def maroc_config() -> None:
+def maroc_config(
+    non_interactive: bool = typer.Option(
+        False, "--non-interactive", help="Use default calibration automatically instead of prompting when a Quabo has none."
+    )
+) -> None:
     """Configure MAROCs based on data_config.json and quabo_calib_*.json."""
     obs_config = config_file.get_obs_config()
     modules = config_file.get_modules(obs_config)
@@ -1202,7 +1206,10 @@ def maroc_config() -> None:
     util.attach_daq_config(daq_config, network_config)
     config_file.associate(daq_config, quabo_uids)
     data_config = config_file.get_data_config()
-    do_maroc_config(modules, quabo_uids, quabo_info, data_config, obs_config, daq_config, network_config, True)
+    do_maroc_config(
+        modules, quabo_uids, quabo_info, data_config, obs_config, daq_config, network_config,
+        verbose=True, non_interactive=non_interactive
+    )
 
 @app.command()
 def mask_config() -> None:

--- a/control/src/control/session_start.py
+++ b/control/src/control/session_start.py
@@ -112,7 +112,10 @@ def session_start(
         quabo_uids = config_file.get_quabo_uids() # type: ignore[assignment]
         if not quabo_uids:
             raise RuntimeError("Missing quabo_uids.json")
-        config.do_maroc_config(modules, quabo_uids, quabo_info, data_config, obs_config, daq_config, network_config, True)
+        config.do_maroc_config(
+            modules, quabo_uids, quabo_info, data_config, obs_config, daq_config, network_config,
+            verbose=True, non_interactive=True
+        )
 
     if stage == 'mask_config':
         stage = 'calibrate_ph'

--- a/control/src/control/tools/hv_updater.py
+++ b/control/src/control/tools/hv_updater.py
@@ -291,6 +291,7 @@ def init_quabo_status(rkey: str, quabo_status: dict[str, Any]) -> None:
         'monitored_hv' : [0, 0, 0, 0],
         'monitored_det_cur' : [0, 0, 0, 0],
         'adjusted_hv' : [0, 0, 0, 0],
+        'no_calib_warned' : False,
     }
 
 def update_all_quabos(r: redis.Redis, quabo_status: dict[str, Any]) -> None:
@@ -359,7 +360,9 @@ def update_all_quabos(r: redis.Redis, quabo_status: dict[str, Any]) -> None:
                         q_info = quabo_info[uid]
                     except Exception:
                         q_info = quabo_info['default']
-                        logger.warning(f'No calibration data: UID - {uid}')
+                        if not quabo_status[rkey]['no_calib_warned']:
+                            logger.warning(f'No calibration data: UID - {uid}')
+                            quabo_status[rkey]['no_calib_warned'] = True
                     detector_serial_nums = [s for s in q_info['detector_serialno']]
                     # record the detector_serial_nums in the quabo_status dict
                     quabo_status[rkey]['detector_serial_nums'] = detector_serial_nums

--- a/control/src/control/transfer/cli.py
+++ b/control/src/control/transfer/cli.py
@@ -1,6 +1,7 @@
 """Transfer queue CLI — `pseti xfr`."""
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import os
@@ -206,18 +207,33 @@ def retry(run_name: Annotated[str, typer.Argument(help="Run name to retry")]) ->
 
 
 @app.command()
-def delete(run_name: Annotated[str, typer.Argument(help="Run name to remove from pending/")]) -> None:
-    """Remove a job from pending/ so the daemon skips it (no data is copied from the DAQ node)."""
+def clean(run_name: Annotated[str, typer.Argument(help="Run name to remove from pending/")]) -> None:
+    """Remove a job from pending/ and try to delete its run directory on each DAQ node.
+
+    The job never reached manifest generation, so there's no verified manifest to
+    checksum against -- this uses CLEANUP_FULL (removes the whole run directory on
+    each DAQ node) rather than the daemon's own selective, manifest-gated cleanup.
+    DAQ-node deletion is best-effort: a node that's unreachable or errors out is
+    reported as a warning but does not undo the local pending/ removal.
+    """
+    from control.transfer.daq_control import cleanup_daq_nodes
     from control.transfer.queue import TransferQueue
 
     console = Console()
     tq = TransferQueue()
 
-    if tq.delete(run_name):
-        console.print(f"[bold green]Success:[/bold green] Removed {run_name} from pending/")
-    else:
+    job = tq.clean(run_name)
+    if job is None:
         console.print(f"[bold red]Error:[/bold red] No pending job found for '{run_name}'")
         raise typer.Exit(1)
+
+    console.print(f"[bold green]Success:[/bold green] Removed {run_name} from pending/")
+
+    errors = asyncio.run(cleanup_daq_nodes(job, mode="CLEANUP_FULL"))
+    if errors:
+        console.print("[bold yellow]Warning:[/bold yellow] Could not clean up on all DAQ nodes:")
+        for err in errors:
+            console.print(f"  [yellow]{err}[/yellow]")
 
 
 @app.command("start")

--- a/control/src/control/transfer/cli.py
+++ b/control/src/control/transfer/cli.py
@@ -205,6 +205,21 @@ def retry(run_name: Annotated[str, typer.Argument(help="Run name to retry")]) ->
         raise typer.Exit(1)
 
 
+@app.command()
+def delete(run_name: Annotated[str, typer.Argument(help="Run name to remove from pending/")]) -> None:
+    """Remove a job from pending/ so the daemon skips it (no data is copied from the DAQ node)."""
+    from control.transfer.queue import TransferQueue
+
+    console = Console()
+    tq = TransferQueue()
+
+    if tq.delete(run_name):
+        console.print(f"[bold green]Success:[/bold green] Removed {run_name} from pending/")
+    else:
+        console.print(f"[bold red]Error:[/bold red] No pending job found for '{run_name}'")
+        raise typer.Exit(1)
+
+
 @app.command("start")
 def start_daemon() -> None:
     """Start the transfer daemon (idempotent: no-op if already running)."""

--- a/control/src/control/transfer/daq_control.py
+++ b/control/src/control/transfer/daq_control.py
@@ -1,0 +1,84 @@
+"""Client-side helpers for the panoseti_grpc daq_control service.
+
+Wraps RPCs on ``panoseti_grpc.daq_control`` for use by both the transfer
+daemon and `pseti xfr` CLI commands, so they share one implementation
+instead of duplicating request-building and per-node fan-out/error-handling.
+Currently only ``CleanupData`` is wrapped; add further daq_control RPC
+wrappers here as they're needed.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from control.utils.util import daq_grpc_endpoint
+
+if TYPE_CHECKING:
+    from control.transfer.models import TransferJob, TransferNodeSpec
+
+try:
+    import panoseti_grpc.daq_control.client as daq_client
+except ImportError:
+    daq_client = None  # type: ignore
+
+
+async def cleanup_daq_nodes(
+    job: TransferJob,
+    *,
+    mode: str,
+    delete_patterns: list[str] | None = None,
+    preserve_patterns: list[str] | None = None,
+) -> list[str]:
+    """Call ``CleanupData`` on every DAQ node named in *job*, in parallel.
+
+    Args:
+        job: The transfer job whose ``daq_nodes`` to clean up.
+        mode: ``"CLEANUP_FULL"`` (rmtree the whole run directory) or
+            ``"CLEANUP_SELECTIVE"`` (delete only *delete_patterns*, keeping
+            *preserve_patterns*). The server enforces a ``manifest_digest``
+            precondition for ``CLEANUP_SELECTIVE``, so only use it once a
+            manifest has actually been verified.
+        delete_patterns: Glob patterns to delete (``CLEANUP_SELECTIVE`` only).
+        preserve_patterns: Glob patterns to keep (``CLEANUP_SELECTIVE`` only).
+
+    Returns:
+        Human-readable error strings, one per node that failed to clean up;
+        empty if every node succeeded. A single explanatory entry is
+        returned if ``panoseti_grpc`` isn't installed.
+    """
+    if daq_client is None:
+        return ["panoseti_grpc not available; skipping DAQ-node cleanup"]  # type: ignore[unreachable]
+
+    errors: list[str] = []
+
+    async def cleanup_node(node: TransferNodeSpec) -> None:
+        host, port = daq_grpc_endpoint(node)
+        request: dict[str, Any] = {
+            "data_dir": node.data_dir,
+            "run_dir": job.run_name,
+            "module_id": node.module_ids,
+            "mode": mode,
+        }
+        if delete_patterns is not None:
+            request["delete_patterns"] = delete_patterns
+        if preserve_patterns is not None:
+            request["preserve_patterns"] = preserve_patterns
+        try:
+            async with daq_client.AsyncDaqControlClient(host=host, port=port) as client:
+                resp = await asyncio.wait_for(client.CleanupData(request), timeout=15.0)
+                if not resp.get("success", True):
+                    errors.append(
+                        f"CleanupData failed for {node.ip_addr}: {resp.get('message', 'unknown error')}"
+                    )
+        except Exception as exc:
+            errors.append(f"CleanupData failed for {node.ip_addr}: {exc}")
+
+    try:
+        async with asyncio.TaskGroup() as tg:
+            for node in job.daq_nodes:
+                tg.create_task(cleanup_node(node))
+    except* Exception as eg:
+        for exc in eg.exceptions:
+            errors.append(f"cleanup_node task failed: {exc}")
+
+    return errors

--- a/control/src/control/transfer/queue.py
+++ b/control/src/control/transfer/queue.py
@@ -221,6 +221,25 @@ class TransferQueue:
         os.unlink(src)
         return True
 
+    def delete(self, run_name: str) -> bool:
+        """Remove a job from pending/ so the daemon never claims it.
+
+        Only ``pending/`` is targeted: a job already claimed into ``active/``
+        is already being transferred and can't be safely skipped this way.
+
+        Args:
+            run_name: The run identifier of the job to remove.
+
+        Returns:
+            ``True`` if a pending job was removed; ``False`` if none existed
+            for *run_name*.
+        """
+        path = self._job_path(TransferStatus.PENDING, run_name)
+        if not path.exists():
+            return False
+        os.unlink(path)
+        return True
+
     def list_jobs(self, bucket: TransferStatus) -> list[str]:
         """Return run names in a queue bucket.
 

--- a/control/src/control/transfer/queue.py
+++ b/control/src/control/transfer/queue.py
@@ -221,7 +221,7 @@ class TransferQueue:
         os.unlink(src)
         return True
 
-    def delete(self, run_name: str) -> bool:
+    def clean(self, run_name: str) -> TransferJob | None:
         """Remove a job from pending/ so the daemon never claims it.
 
         Only ``pending/`` is targeted: a job already claimed into ``active/``
@@ -231,14 +231,18 @@ class TransferQueue:
             run_name: The run identifier of the job to remove.
 
         Returns:
-            ``True`` if a pending job was removed; ``False`` if none existed
-            for *run_name*.
+            The removed ``TransferJob`` (so callers can still see which DAQ
+            nodes it named, e.g. to also clean up remotely), or ``None`` if
+            no pending job existed for *run_name*.
         """
         path = self._job_path(TransferStatus.PENDING, run_name)
         if not path.exists():
-            return False
+            return None
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+        job = TransferJob.model_validate(data)
         os.unlink(path)
-        return True
+        return job
 
     def list_jobs(self, bucket: TransferStatus) -> list[str]:
         """Return run names in a queue bucket.

--- a/control/uv.lock
+++ b/control/uv.lock
@@ -1232,7 +1232,7 @@ wheels = [
 
 [[package]]
 name = "panoseti-grpc"
-version = "0.4.16"
+version = "0.4.17"
 source = { editable = "../grpc" }
 dependencies = [
     { name = "anyio" },

--- a/control/uv.lock
+++ b/control/uv.lock
@@ -1454,7 +1454,7 @@ wheels = [
 
 [[package]]
 name = "pseti-ctl"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,0 @@
-[project]
-name = "panoseti-software"
-version = "0.1.0"
-requires-python = ">=3.14"
-dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.14"
-
-[[package]]
-name = "panoseti-software"
-version = "0.1.0"
-source = { virtual = "." }


### PR DESCRIPTION
## Summary
- `pseti xfr clean <run_name>` (new `transfer/daq_control.py`): removes a job from the transfer queue's `pending/` bucket so the daemon skips it, and best-effort deletes that run's directory on every DAQ node via a shared `CleanupData` RPC wrapper (`CLEANUP_FULL`, since a still-pending job never had a manifest generated for the server's manifest-gated `CLEANUP_SELECTIVE` mode). Remote failures are reported as warnings and don't undo the local removal.
- `pseti cfg maroc-config` gains a `--non-interactive` flag (default off) to skip the Y/N prompt when falling back to default calibration; `session_start.py`'s automated flow now passes `non_interactive=True`. Both call sites had been passing `True` positionally into the wrong parameter (`verbose`, not `non_interactive`) due to the function's argument order.
- `hv_updater.py` now logs "No calibration data: UID - ..." once per quabo instead of every 3-second cycle.
- `pseti admin status` issues a single `docker compose ps -p <project>` call per DAQ node instead of two identical ones (the second only reprinted the same table and triggered a spurious `WARN[0000]` from unresolved `${HOSTNAME}` interpolation); bumps the `panoseti_grpc` submodule pointer.
- Removed the dead root-level `pyproject.toml`/`uv.lock` (unused workspace scaffolding with no `[tool.uv.workspace]` linkage, no CI usage, no `.venv` -- `control/pyproject.toml` is the real package manifest).

## Test plan
- [x] New `TestClean` unit tests for `TransferQueue.clean()` pass (`pytest src/ci/software_only/tier1_unit/test_transfer_queue.py`)
- [x] `ruff check` / `mypy` pass on the changed transfer/ modules
- [ ] `pseti cfg maroc-config` (with and without `--non-interactive`) and `pseti admin status` against real hardware/containers