### PR TITLE
Add pseti --env-template, update grpc submodule to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "grpc"]
 	path = grpc
 	url = https://github.com/panoseti/panoseti_grpc.git
-	branch = dev
+	branch = main
 [submodule "web"]
 	path = web
 	url = https://github.com/panoseti/panoseti_web.git

--- a/control/CLI.md
+++ b/control/CLI.md
@@ -7,6 +7,7 @@ The `pseti` command is the unified entry point for the PSETI observatory control
 - `-h`, `--help`: Show the help message and exit.
 - `-t`, `--tree`: Display the command tree for the current hierarchy and exit.
 - `--no-env`: Disable automatic loading of `.env` files.
+- `--env-template`: Copy the packaged `.env.example` to `./.env_pseti_<timestamp>` and exit.
 
 ---
 

--- a/control/src/control/pseti.py
+++ b/control/src/control/pseti.py
@@ -1,5 +1,8 @@
 import importlib.metadata
+import shutil
 import sys
+from datetime import datetime
+from pathlib import Path
 from typing import Annotated, Any
 
 from control.utils.env_loader import load_pseti_env
@@ -12,11 +15,27 @@ if "--no-env" not in sys.argv:
 import typer
 from panoseti_grpc.util.cli import BaseLazyGroup, display_tree_callback
 
+from control.utils.paths import PanoPaths
+
 
 def _version_callback(value: bool) -> None:
     if value:
         print(f"pseti {importlib.metadata.version('pseti-ctl')}")
         raise typer.Exit()
+
+
+def _env_template_callback(value: bool) -> None:
+    if not value:
+        return
+    src = PanoPaths.software_root_dir() / ".env.example"
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    dest = Path.cwd() / f".env_pseti_{timestamp}"
+    if dest.exists():
+        print(f"Refusing to overwrite existing file: {dest}")
+        raise typer.Exit(code=1)
+    shutil.copyfile(src, dest)
+    print(f"Wrote .env template to {dest}")
+    raise typer.Exit()
 
 
 class PanoLazyGroup(BaseLazyGroup):
@@ -75,6 +94,15 @@ def main_callback(
             "--version",
             help="Print the installed pseti-ctl package version and exit.",
             callback=_version_callback,
+            is_eager=True,
+        ),
+    ] = False,
+    env_template: Annotated[
+        bool,
+        typer.Option(
+            "--env-template",
+            help="Copy the packaged .env.example to ./.env_pseti_<timestamp> and exit.",
+            callback=_env_template_callback,
             is_eager=True,
         ),
     ] = False,

--- a/control/uv.lock
+++ b/control/uv.lock
@@ -1232,7 +1232,7 @@ wheels = [
 
 [[package]]
 name = "panoseti-grpc"
-version = "0.4.17"
+version = "0.4.19"
 source = { editable = "../grpc" }
 dependencies = [
     { name = "anyio" },
@@ -1253,6 +1253,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pyserial" },
+    { name = "python-dotenv" },
     { name = "pyubx2" },
     { name = "redis" },
     { name = "requests" },
@@ -1289,6 +1290,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-timeout", marker = "extra == 'dev'" },
+    { name = "python-dotenv" },
     { name = "pyubx2" },
     { name = "redis", specifier = ">=7" },
     { name = "requests" },


### PR DESCRIPTION
## Summary
- `pseti --env-template`: new global option (mirrors the same option on `pseti-gui`/`pseti-grpc`) that copies the packaged `.env.example` to `./.env_pseti_<timestamp>`, resolved via `PanoPaths.software_root_dir()` so it works regardless of cwd.
- Bump the `grpc` submodule pointer to `main`'s latest (`v0.4.19`), which itself adds `panoseti_grpc`'s own `--env-template` option and fixes `.env_example` packaging (previously missing from installed wheels).
- Sync `control/uv.lock`'s editable `panoseti-grpc` entry to `0.4.19` and its new `python-dotenv` dependency.
- `.gitmodules`: track `grpc`'s `main` branch instead of `dev`, matching where the submodule is now pinned.

## Test plan
- [x] `pseti --env-template` manually verified: correct timestamped filename, correct content, refuses to overwrite an existing file
- [x] `ruff`/`mypy` pass on `control/src/control/pseti.py`