### PR TITLE
Fix sw_info.json path, resolve gRPC ports via network_config.json

### DIFF
--- a/control/CLI.md
+++ b/control/CLI.md
@@ -7,7 +7,7 @@ The `pseti` command is the unified entry point for the PSETI observatory control
 - `-h`, `--help`: Show the help message and exit.
 - `-t`, `--tree`: Display the command tree for the current hierarchy and exit.
 - `--no-env`: Disable automatic loading of `.env` files.
-- `--env-template`: Copy the packaged `.env.example` to `./.env_pseti_<timestamp>` and exit.
+- `--env-template`: Copy the packaged `.env.example` to `./.env_pseti_<timestamp>` and exit. Point `PSETI_ENV_FILE` at the generated file to load it.
 
 ---
 

--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -77,6 +77,15 @@ dependencies = [
   where = ["src"]
   include = ["control*", "ci*"]
 
+  [tool.setuptools.package-data]
+  # quabo_config.txt is read via a __file__-relative path (control/config.py's
+  # CONTROL_DRIVER_DIR) at module import time -- setuptools only bundles .py
+  # files by default, so a non-editable install (uv tool install pseti-ctl,
+  # without --editable) silently drops it, breaking every command that
+  # imports control.config (cfg, val, stop, session-start, ...) with
+  # "No such file or directory" the moment they're imported.
+  "control.driver" = ["quabo_config.txt"]
+
   [tool.pytest.ini_options]
   pythonpath = ["src"]
   testpaths = ["src/ci"]

--- a/control/src/ci/fixtures/configs/chaos/network_config.json
+++ b/control/src/ci/fixtures/configs/chaos/network_config.json
@@ -1,4 +1,5 @@
 {
+    "headnode": { "grpc_port": 50051 },
     "modules": [
         {
             "ip_addr": "192.168.3.248",
@@ -12,10 +13,12 @@
     "daq_nodes": [
         {
             "ip_addr": "192.168.0.10",
+            "grpc_port": 50051,
             "port_forwarding": { "status": false, "gw_ip": "10.0.1.254", "grpc_port": 50051 }
         },
         {
             "ip_addr": "192.168.0.20",
+            "grpc_port": 50051,
             "port_forwarding": { "status": false, "gw_ip": "10.0.1.254", "grpc_port": 50051 }
         }
     ]

--- a/control/src/ci/fixtures/configs/direct/network_config.json
+++ b/control/src/ci/fixtures/configs/direct/network_config.json
@@ -1,4 +1,5 @@
 {
+    "headnode": { "grpc_port": 50051 },
     "modules": [
         {
             "ip_addr": "192.168.3.248",
@@ -12,10 +13,12 @@
     "daq_nodes": [
         {
             "ip_addr": "192.168.0.10",
+            "grpc_port": 50051,
             "port_forwarding": { "status": false, "gw_ip": "10.0.1.254", "grpc_port": 50051 }
         },
         {
             "ip_addr": "192.168.0.20",
+            "grpc_port": 50051,
             "port_forwarding": { "status": false, "gw_ip": "10.0.1.254", "grpc_port": 50051 }
         }
     ]

--- a/control/src/ci/fixtures/configs/gateway/network_config.json
+++ b/control/src/ci/fixtures/configs/gateway/network_config.json
@@ -1,4 +1,5 @@
 {
+    "headnode": { "grpc_port": 50051 },
     "modules": [
         {
             "ip_addr": "192.168.3.32",
@@ -24,10 +25,12 @@
     "daq_nodes": [
         {
             "ip_addr": "192.168.0.10",
+            "grpc_port": 50051,
             "port_forwarding": { "status": true, "gw_ip": "10.0.1.254", "grpc_port": 50051 }
         },
         {
             "ip_addr": "192.168.0.20",
+            "grpc_port": 50051,
             "port_forwarding": { "status": true, "gw_ip": "10.0.1.254", "grpc_port": 50051 }
         }
     ]

--- a/control/src/ci/hardware_software/configs/network_config.json
+++ b/control/src/ci/hardware_software/configs/network_config.json
@@ -1,4 +1,7 @@
 {
+    "headnode": {
+        "grpc_port": 50051
+    },
     "modules": [
         {
             "ip_addr": "192.168.3.248",
@@ -23,6 +26,7 @@
     "daq_nodes": [
         {
             "ip_addr": "192.168.0.228",
+            "grpc_port": 50051,
             "port_forwarding": {
                 "status": true,
                 "gw_ip": "192.168.88.152",

--- a/control/src/ci/scripts/entrypoint-headnode-hw.sh
+++ b/control/src/ci/scripts/entrypoint-headnode-hw.sh
@@ -32,7 +32,8 @@ if [ "$(id -u)" = "0" ]; then
     chown "${TARGET_UID}:${TARGET_GID}" "${DATA_DIR}" 2>/dev/null || true
 
     # Ensure any metadata files created by root (like sw_info.json or flashuid) are fixed
-    [ -f /app/sw_info.json ] && chown "${TARGET_UID}:${TARGET_GID}" /app/sw_info.json 2>/dev/null || true
+    TMP_DIR="${PSETI_TMP:-/app/tmp}"
+    [ -f "${TMP_DIR}/sw_info.json" ] && chown "${TARGET_UID}:${TARGET_GID}" "${TMP_DIR}/sw_info.json" 2>/dev/null || true
     [ -f /app/flashuid ] && chown "${TARGET_UID}:${TARGET_GID}" /app/flashuid 2>/dev/null || true
 fi
 

--- a/control/src/ci/software_only/tier1_unit/test_grpc_endpoint.py
+++ b/control/src/ci/software_only/tier1_unit/test_grpc_endpoint.py
@@ -19,8 +19,14 @@ from __future__ import annotations
 
 import pytest
 
-from control.utils.pydantic_config_models import DaqNode, PortForwarding
-from control.utils.util import daq_grpc_endpoint, resolve_grpc_port
+from control.utils.pydantic_config_models import (
+    DaqConfig,
+    DaqNode,
+    NetworkConfig,
+    NetworkDaqNode,
+    PortForwarding,
+)
+from control.utils.util import attach_daq_config, daq_grpc_endpoint, resolve_grpc_port
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -176,3 +182,70 @@ class TestPortForwardingGrpcPortDefault:
     def test_explicit_grpc_port_still_respected(self) -> None:
         pf = PortForwarding(status=True, gw_ip="10.0.1.254", grpc_port=12345)
         assert pf.grpc_port == 12345
+
+
+# ---------------------------------------------------------------------------
+# attach_daq_config() -- network_config.json's direct-connect grpc_port as
+# a new middle precedence tier between daq_config.json's own explicit
+# override and resolve_grpc_port()'s env var / 50051 default.
+# ---------------------------------------------------------------------------
+
+
+def _network_config(**node_overrides: object) -> NetworkConfig:
+    defaults: dict = dict(
+        ip_addr="192.168.0.228",
+        port_forwarding=PortForwarding(status=False, gw_ip="10.0.1.254"),
+    )
+    defaults.update(node_overrides)
+    return NetworkConfig(daq_nodes=[NetworkDaqNode(**defaults)])  # type: ignore
+
+
+class TestAttachDaqConfigGrpcPort:
+    def test_network_config_grpc_port_fills_in_when_daq_node_unset(self) -> None:
+        daq_config = DaqConfig(head_node_data_dir="/data/head", head_node_ip_addr="10.99.99.99", daq_nodes=[_daq_node(ip_addr="192.168.0.228")])
+        network_config = _network_config(ip_addr="192.168.0.228", grpc_port=50077)
+
+        attach_daq_config(daq_config, network_config)
+
+        assert daq_config.daq_nodes[0].grpc_port == 50077
+
+    def test_daq_config_own_explicit_grpc_port_wins_over_network_config(self) -> None:
+        daq_config = DaqConfig(
+            head_node_data_dir="/data/head",
+            head_node_ip_addr="10.99.99.99",
+            daq_nodes=[_daq_node(ip_addr="192.168.0.228", grpc_port=50099)],
+        )
+        network_config = _network_config(ip_addr="192.168.0.228", grpc_port=50077)
+
+        attach_daq_config(daq_config, network_config)
+
+        assert daq_config.daq_nodes[0].grpc_port == 50099
+
+    def test_neither_set_stays_none(self) -> None:
+        daq_config = DaqConfig(head_node_data_dir="/data/head", head_node_ip_addr="10.99.99.99", daq_nodes=[_daq_node(ip_addr="192.168.0.228")])
+        network_config = _network_config(ip_addr="192.168.0.228")
+
+        attach_daq_config(daq_config, network_config)
+
+        assert daq_config.daq_nodes[0].grpc_port is None
+
+    def test_no_matching_network_config_node_leaves_grpc_port_unset(self) -> None:
+        daq_config = DaqConfig(head_node_data_dir="/data/head", head_node_ip_addr="10.99.99.99", daq_nodes=[_daq_node(ip_addr="192.168.0.228")])
+        network_config = _network_config(ip_addr="10.0.0.99", grpc_port=50077)
+
+        attach_daq_config(daq_config, network_config)
+
+        assert daq_config.daq_nodes[0].grpc_port is None
+
+    def test_end_to_end_daq_grpc_endpoint_resolves_network_config_port(self) -> None:
+        """The full chain: network_config.json's sibling grpc_port reaches
+        daq_grpc_endpoint()'s resolved (host, port) via attach_daq_config(),
+        with no changes needed to daq_grpc_endpoint() itself.
+        """
+        daq_config = DaqConfig(head_node_data_dir="/data/head", head_node_ip_addr="10.99.99.99", daq_nodes=[_daq_node(ip_addr="192.168.0.228")])
+        network_config = _network_config(ip_addr="192.168.0.228", grpc_port=50077)
+
+        attach_daq_config(daq_config, network_config)
+        node = daq_config.daq_nodes[0]
+
+        assert daq_grpc_endpoint(node, daq_config) == ("192.168.0.228", 50077)

--- a/control/src/ci/software_only/tier1_unit/test_grpc_endpoint.py
+++ b/control/src/ci/software_only/tier1_unit/test_grpc_endpoint.py
@@ -25,6 +25,7 @@ from control.utils.pydantic_config_models import (
     NetworkConfig,
     NetworkDaqNode,
     PortForwarding,
+    TransferNodeSpec,
 )
 from control.utils.util import attach_daq_config, daq_grpc_endpoint, resolve_grpc_port
 
@@ -249,3 +250,48 @@ class TestAttachDaqConfigGrpcPort:
         node = daq_config.daq_nodes[0]
 
         assert daq_grpc_endpoint(node, daq_config) == ("192.168.0.228", 50077)
+
+
+# ---------------------------------------------------------------------------
+# TransferNodeSpec -- the Transfer Daemon's node type. It never has a
+# daq_config to pass to daq_grpc_endpoint() (it only ever sees the snapshot
+# in the job TOML), so its own grpc_port override is the only way it can
+# reach a non-default direct-connection port.
+# ---------------------------------------------------------------------------
+
+
+def _transfer_node(**overrides: object) -> TransferNodeSpec:
+    defaults: dict = dict(
+        username="panoseti",
+        data_dir="/data",
+        ip_addr="192.168.0.228",
+        module_ids=[254],
+    )
+    defaults.update(overrides)
+    return TransferNodeSpec(**defaults)
+
+
+class TestDaqGrpcEndpointWithTransferNodeSpec:
+    def test_direct_node_with_own_grpc_port_override_wins_over_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """TransferNodeSpec.grpc_port must be honored the same way DaqNode.grpc_port is --
+        this is the only way the Transfer Daemon (which never has a daq_config to pass to
+        daq_grpc_endpoint()) can resolve a per-node port override."""
+        monkeypatch.setenv("DAQNODE_GRPC_PORT", "50099")
+        node = _transfer_node(ip_addr="10.0.0.6", grpc_port=60000)
+        assert daq_grpc_endpoint(node, daq_config=None) == ("10.0.0.6", 60000)
+
+    def test_direct_node_without_override_falls_back_to_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DAQNODE_GRPC_PORT", "50099")
+        node = _transfer_node(ip_addr="10.0.0.7")
+        assert daq_grpc_endpoint(node, daq_config=None) == ("10.0.0.7", 50099)
+
+    def test_forwarded_node_with_explicit_grpc_port_uses_gateway(self) -> None:
+        node = _transfer_node(
+            ip_addr="10.0.0.8",
+            port_forwarding=PortForwarding(status=True, gw_ip="10.0.1.254", grpc_port=12345),
+        )
+        assert daq_grpc_endpoint(node, daq_config=None) == ("10.0.1.254", 12345)

--- a/control/src/ci/software_only/tier1_unit/test_health_port_collision.py
+++ b/control/src/ci/software_only/tier1_unit/test_health_port_collision.py
@@ -1,0 +1,184 @@
+"""
+test_health_port_collision.py
+
+Unit tests for control.health._check_port_collision() -- pure, no-network
+detection of a co-located head+DAQ node gRPC port collision.
+
+Precedence under test: network_config.json's headnode.grpc_port / a node's
+own grpc_port (via attach_daq_config) > the HEADNODE_GRPC_PORT/DAQNODE_GRPC_PORT
+env vars > the 50051 default -- same resolution _check_grpc_headnode() and
+_check_grpc_daq_nodes() use, so this check can't disagree with what those
+two actually probe.
+"""
+from __future__ import annotations
+
+import pytest
+
+import control.utils.config_file as config_file_mod
+from control.health import _check_port_collision
+from control.utils.pydantic_config_models import (
+    DaqConfig,
+    DaqNode,
+    NetworkConfig,
+    NetworkDaqNode,
+    NetworkHeadnode,
+    PortForwarding,
+)
+
+_PORT_ENV_VARS = ("HEADNODE_GRPC_PORT", "DAQNODE_GRPC_PORT", "DAQ_DATA_GATEWAY_PORT", "GRPC_PORT")
+
+
+@pytest.fixture(autouse=True)
+def _clean_port_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in _PORT_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _co_located_daq_config(**node_overrides: object) -> DaqConfig:
+    """A single DAQ node co-located with the head node (head_node_container=True
+    is the deterministic, network-free way is_local() reports True in CI --
+    see control/CLAUDE.md's "Validation Leniency" note).
+    """
+    node_defaults: dict = dict(
+        username="panoseti",
+        data_dir="/data",
+        ip_addr="10.0.0.1",
+        module_ids=[0],
+    )
+    node_defaults.update(node_overrides)
+    return DaqConfig(
+        head_node_data_dir="/data/head",
+        head_node_ip_addr="10.0.0.1",
+        head_node_container=True,
+        daq_nodes=[DaqNode(**node_defaults)],
+    )
+
+
+def _patch_configs(monkeypatch: pytest.MonkeyPatch, daq_config: DaqConfig, network_config: NetworkConfig) -> None:
+    monkeypatch.setattr(config_file_mod, "get_daq_config", lambda *a, **kw: daq_config)
+    monkeypatch.setattr(config_file_mod, "get_network_config", lambda *a, **kw: network_config)
+
+
+class TestPortCollisionPrecedence:
+    def test_env_vars_only_no_collision(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HEADNODE_GRPC_PORT", "50051")
+        monkeypatch.setenv("DAQNODE_GRPC_PORT", "50052")
+        _patch_configs(monkeypatch, _co_located_daq_config(), NetworkConfig())
+
+        results = _check_port_collision()
+
+        assert len(results) == 1
+        _name, ok, detail = results[0]
+        assert ok is True
+        assert "50051" in detail and "50052" in detail
+
+    def test_env_vars_only_collision_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HEADNODE_GRPC_PORT", "50051")
+        monkeypatch.setenv("DAQNODE_GRPC_PORT", "50051")
+        _patch_configs(monkeypatch, _co_located_daq_config(), NetworkConfig())
+
+        results = _check_port_collision()
+
+        assert len(results) == 1
+        _name, ok, detail = results[0]
+        assert ok is False
+        assert "50051" in detail
+
+    def test_network_config_headnode_port_takes_precedence_over_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """headnode.grpc_port=60051 in network_config.json must win over
+        HEADNODE_GRPC_PORT=50051 -- resolving a *false* collision (env vars
+        alone would show 50051 == 50051) once the explicit override applies.
+        """
+        monkeypatch.setenv("HEADNODE_GRPC_PORT", "50051")
+        monkeypatch.setenv("DAQNODE_GRPC_PORT", "50051")
+        network_config = NetworkConfig(headnode=NetworkHeadnode(grpc_port=60051))
+        _patch_configs(monkeypatch, _co_located_daq_config(), network_config)
+
+        results = _check_port_collision()
+
+        assert len(results) == 1
+        _name, ok, detail = results[0]
+        assert ok is True
+        assert "60051" in detail and "50051" in detail
+
+    def test_network_config_daq_node_port_takes_precedence_over_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A node's own network_config.json grpc_port must win over DAQNODE_GRPC_PORT."""
+        monkeypatch.setenv("HEADNODE_GRPC_PORT", "50051")
+        monkeypatch.setenv("DAQNODE_GRPC_PORT", "50051")
+        network_config = NetworkConfig(
+            daq_nodes=[
+                NetworkDaqNode(
+                    ip_addr="10.0.0.1",  # type: ignore
+                    grpc_port=60052,
+                    port_forwarding=PortForwarding(status=False, gw_ip="10.0.1.254"),
+                )
+            ]
+        )
+        _patch_configs(monkeypatch, _co_located_daq_config(), network_config)
+
+        results = _check_port_collision()
+
+        assert len(results) == 1
+        _name, ok, detail = results[0]
+        assert ok is True
+        assert "60052" in detail
+
+    def test_network_config_still_collides_when_both_set_equal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """network_config.json's precedence doesn't hide a real collision it introduces itself."""
+        network_config = NetworkConfig(
+            headnode=NetworkHeadnode(grpc_port=60051),
+            daq_nodes=[
+                NetworkDaqNode(
+                    ip_addr="10.0.0.1",  # type: ignore
+                    grpc_port=60051,
+                    port_forwarding=PortForwarding(status=False, gw_ip="10.0.1.254"),
+                )
+            ],
+        )
+        _patch_configs(monkeypatch, _co_located_daq_config(), network_config)
+
+        results = _check_port_collision()
+
+        assert len(results) == 1
+        _name, ok, _detail = results[0]
+        assert ok is False
+
+    def test_daq_config_own_explicit_grpc_port_still_wins_over_network_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """daq_config.json's own per-node override (highest precedence in
+        attach_daq_config()) still beats network_config.json's value here too.
+        """
+        network_config = NetworkConfig(
+            daq_nodes=[
+                NetworkDaqNode(
+                    ip_addr="10.0.0.1",  # type: ignore
+                    grpc_port=60052,
+                    port_forwarding=PortForwarding(status=False, gw_ip="10.0.1.254"),
+                )
+            ]
+        )
+        daq_config = _co_located_daq_config(grpc_port=60099)
+        _patch_configs(monkeypatch, daq_config, network_config)
+
+        results = _check_port_collision()
+
+        assert len(results) == 1
+        _name, _ok, detail = results[0]
+        assert "60099" in detail
+
+    def test_non_co_located_node_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A node that isn't local to the head node is never checked -- no collision is possible."""
+        daq_config = DaqConfig(
+            head_node_data_dir="/data/head",
+            head_node_ip_addr="10.0.0.1",
+            head_node_container=False,
+            daq_nodes=[
+                DaqNode(username="panoseti", data_dir="/data", ip_addr="192.168.0.10", module_ids=[0])
+            ],
+        )
+        _patch_configs(monkeypatch, daq_config, NetworkConfig())
+
+        results = _check_port_collision()
+
+        assert results == []

--- a/control/src/ci/software_only/tier1_unit/test_pydantic_models_2.py
+++ b/control/src/ci/software_only/tier1_unit/test_pydantic_models_2.py
@@ -20,6 +20,9 @@ from control.utils.pydantic_config_models import (
     FirmwareConfig,
     FlashParams,
     InterleaveState,
+    NetworkConfig,
+    NetworkDaqNode,
+    NetworkHeadnode,
     ObsConfig,
     ObsDomeConfig,
     ObsModuleConfig,
@@ -465,3 +468,70 @@ class TestPortForwarding:
         """grpc_port=65535 is the highest valid value."""
         pf = PortForwarding(**self._BASE, grpc_port=65535)  # type: ignore
         assert pf.grpc_port == 65535
+
+
+# ===========================================================================
+# NetworkConfig / NetworkDaqNode / NetworkHeadnode
+# ===========================================================================
+
+class TestNetworkHeadnode:
+    def test_defaults_to_none_when_omitted(self) -> None:
+        """None (not a 50051 literal) so callers can distinguish "operator
+        set it in network_config.json" from "field default" -- see
+        health.py's _check_grpc_headnode(), which passes this straight
+        through as resolve_grpc_port()'s explicit override and only then
+        falls through to HEADNODE_GRPC_PORT / the 50051 default.
+        """
+        cfg = NetworkConfig()
+        assert cfg.headnode.grpc_port is None
+
+    def test_explicit_value(self) -> None:
+        cfg = NetworkConfig(headnode=NetworkHeadnode(grpc_port=60051))
+        assert cfg.headnode.grpc_port == 60051
+
+    def test_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            NetworkHeadnode(grpc_port=70000)  # type: ignore
+
+
+class TestNetworkDaqNode:
+    """NetworkDaqNode.grpc_port is a sibling of port_forwarding -- used for
+    direct connections when port_forwarding.status is False. Distinct from
+    port_forwarding.grpc_port, which only applies when status is True.
+    """
+
+    def test_grpc_port_defaults_to_none_when_omitted(self) -> None:
+        """None (not a 50051 literal) so attach_daq_config() can tell "not
+        set in network_config.json" apart from "explicitly set" and only
+        seed daq_config.json's DaqNode.grpc_port when it's itself unset.
+        """
+        node = NetworkDaqNode(
+            ip_addr="192.168.0.10",  # type: ignore
+            port_forwarding=PortForwarding(status=False, gw_ip="10.0.1.254"),
+        )
+        assert node.grpc_port is None
+
+    def test_grpc_port_explicit_value(self) -> None:
+        node = NetworkDaqNode(
+            ip_addr="192.168.0.10",  # type: ignore
+            grpc_port=50077,
+            port_forwarding=PortForwarding(status=False, gw_ip="10.0.1.254"),
+        )
+        assert node.grpc_port == 50077
+
+    def test_grpc_port_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            NetworkDaqNode(
+                ip_addr="192.168.0.10",  # type: ignore
+                grpc_port=0,  # type: ignore
+                port_forwarding=PortForwarding(status=False, gw_ip="10.0.1.254"),
+            )
+
+    def test_grpc_port_independent_of_port_forwarding_grpc_port(self) -> None:
+        node = NetworkDaqNode(
+            ip_addr="192.168.0.10",  # type: ignore
+            grpc_port=50077,
+            port_forwarding=PortForwarding(status=True, gw_ip="10.0.1.254", grpc_port=50099),
+        )
+        assert node.grpc_port == 50077
+        assert node.port_forwarding.grpc_port == 50099

--- a/control/src/ci/software_only/tier1_unit/test_pydantic_models_transfer.py
+++ b/control/src/ci/software_only/tier1_unit/test_pydantic_models_transfer.py
@@ -55,6 +55,38 @@ class TestTransferNodeSpec:
         assert str(spec.port_forwarding.gw_ip) == "10.0.1.254"
         assert spec.port_forwarding.grpc_port == 50051
 
+    def test_grpc_port_defaults_to_none(self):
+        """TransferNodeSpec.grpc_port defaults to None when omitted."""
+        spec = TransferNodeSpec(
+            ip_addr="192.168.0.10",
+            username="daq_user",
+            data_dir="/data/runs",
+            module_ids=[0, 1],
+        )
+        assert spec.grpc_port is None
+
+    def test_grpc_port_explicit_value(self):
+        """TransferNodeSpec.grpc_port accepts an explicit override."""
+        spec = TransferNodeSpec(
+            ip_addr="192.168.0.10",
+            username="daq_user",
+            data_dir="/data/runs",
+            module_ids=[0, 1],
+            grpc_port=50099,
+        )
+        assert spec.grpc_port == 50099
+
+    def test_grpc_port_out_of_range_raises(self):
+        """TransferNodeSpec.grpc_port validates the port range like DaqNode.grpc_port."""
+        with pytest.raises(ValidationError):
+            TransferNodeSpec(
+                ip_addr="192.168.0.10",
+                username="daq_user",
+                data_dir="/data/runs",
+                module_ids=[0, 1],
+                grpc_port=0,
+            )
+
     def test_node_spec_rejects_extra_fields(self):
         """TransferNodeSpec rejects extra fields (BaseStrictModel)."""
         with pytest.raises(ValidationError):  # Pydantic validation error

--- a/control/src/ci/software_only/tier1_unit/test_stop_fast_path.py
+++ b/control/src/ci/software_only/tier1_unit/test_stop_fast_path.py
@@ -79,6 +79,29 @@ def daq_config(tmp_path, monkeypatch) -> DaqConfig:
 
 
 @pytest.fixture
+def daq_config_with_grpc_port(tmp_path, monkeypatch) -> DaqConfig:
+    """Same as daq_config, but the DAQ node carries an explicit grpc_port override."""
+    monkeypatch.setenv("PSETI_STATE", str(tmp_path))
+    monkeypatch.setenv("PSETI_TQ_DIR", str(tmp_path / "state" / "transfer" / "queue"))
+
+    return DaqConfig(
+        head_node_data_dir=str(tmp_path),
+        head_node_ip_addr="127.0.0.1",
+        head_node_container=True,
+        daq_nodes=[
+            {
+                "username": "panoseti",
+                "data_dir": str(tmp_path),
+                "ip_addr": "127.0.0.2",
+                "module_ids": [254],
+                "bindhost": "lo",
+                "grpc_port": 50099,
+            }
+        ],
+    )
+
+
+@pytest.fixture
 def network_config() -> NetworkConfig:
     return NetworkConfig()
 
@@ -227,6 +250,38 @@ class TestStopFastPath:
         assert pending_job.exists(), (
             f"Expected pending transfer job at {pending_job}.\n"
             "stop_run() must enqueue the run for background transfer after hardware teardown."
+        )
+
+    async def test_stop_enqueues_transfer_job_with_grpc_port(
+        self, tmp_path, run_dir, state_mgr, daq_config_with_grpc_port, network_config, quabo_uids
+    ):
+        """A node's daq_config.json grpc_port override must be snapshotted into the job TOML."""
+        import tomllib
+
+        from ci.fixtures.adapters.fake_adapters import (
+            FakeFileSystemManager,
+            FakeNetworkClient,
+            FakeProcessManager,
+        )
+        with _stop_patches(state_mgr):
+            await stop.stop_run(
+                daq_config_with_grpc_port,
+                network_config,
+                quabo_uids,
+                FakeProcessManager(),
+                FakeNetworkClient(),
+                FakeFileSystemManager(),
+                run=RUN_NAME,
+                no_collect=True,
+                no_cleanup=True,
+            )
+
+        pending_job = tmp_path / "state" / "transfer" / "queue" / "pending" / f"{RUN_NAME}.job.toml"
+        data = tomllib.loads(pending_job.read_text())
+
+        assert data["daq_nodes"][0]["grpc_port"] == 50099, (
+            "stop_run() must carry the DAQ node's daq_config.json grpc_port override "
+            "into the TransferNodeSpec written to the job TOML."
         )
 
     async def test_stop_ledger_recording_ended(

--- a/control/src/ci/software_only/tier1_unit/test_transfer_queue.py
+++ b/control/src/ci/software_only/tier1_unit/test_transfer_queue.py
@@ -213,6 +213,28 @@ class TestClean:
         assert tq.clean("run_011") is None
         assert (tq._queue / "active" / "run_011.job.toml").exists()
 
+    def test_clean_removes_failed(self, tq: TransferQueue) -> None:
+        """clean() must also find and remove a job sitting in failed/."""
+        tq.enqueue(_make_job("run_012"))
+        tq.claim()
+        tq.fail("run_012")
+        assert (tq._queue / "failed" / "run_012.job.toml").exists()
+
+        removed = tq.clean("run_012")
+        assert removed is not None
+        assert removed.run_name == "run_012"
+        assert not (tq._queue / "failed" / "run_012.job.toml").exists()
+
+    def test_clean_does_not_touch_completed(self, tq: TransferQueue) -> None:
+        """clean() must not remove a job that already finished successfully."""
+        tq.enqueue(_make_job("run_013"))
+        tq.claim()
+        tq.complete("run_013")
+        assert (tq._queue / "completed" / "run_013.job.toml").exists()
+
+        assert tq.clean("run_013") is None
+        assert (tq._queue / "completed" / "run_013.job.toml").exists()
+
 
 class TestListJobs:
     def test_list_jobs_pending(self, tq: TransferQueue) -> None:

--- a/control/src/ci/software_only/tier1_unit/test_transfer_queue.py
+++ b/control/src/ci/software_only/tier1_unit/test_transfer_queue.py
@@ -263,3 +263,33 @@ class TestRoundTrip:
 
         assert claimed is not None
         assert claimed.daq_nodes[0].port_forwarding is None
+        assert claimed.daq_nodes[0].grpc_port is None
+
+    def test_roundtrip_grpc_port_explicit(self, tq: TransferQueue) -> None:
+        """A node's explicit grpc_port override survives serialize/deserialize."""
+        original = _make_job(
+            "grpc_port_run",
+            daq_nodes=[
+                TransferNodeSpec(
+                    ip_addr=IPv4Address("192.168.0.10"),
+                    username="panoseti",
+                    data_dir="/data",
+                    module_ids=[0, 1],
+                    grpc_port=50099,
+                )
+            ],
+        )
+        tq.enqueue(original)
+        claimed = tq.claim()
+
+        assert claimed is not None
+        assert claimed.daq_nodes[0].grpc_port == 50099
+
+    def test_roundtrip_grpc_port_unset_stays_none(self, tq: TransferQueue) -> None:
+        """An omitted grpc_port must round-trip as None, not the string 'None'."""
+        original = _make_job("grpc_port_unset_run")
+        tq.enqueue(original)
+        claimed = tq.claim()
+
+        assert claimed is not None
+        assert claimed.daq_nodes[0].grpc_port is None

--- a/control/src/control/hardware_ops.py
+++ b/control/src/control/hardware_ops.py
@@ -165,19 +165,9 @@ def make_run_dirs(
                 shutil.copy2(item, Path(run_dir) / item.name)
 
     # Explicitly ensure sw_info.json and ph_baseline.json are captured from their primary locations
-    # We check multiple likely paths for sw_info.json to ensure it's captured in both host and Docker environments.
-    sw_info_paths = [
-        PanoPaths.software_root_dir() / config_file.sw_info_filename,
-        PanoPaths.base_dir() / config_file.sw_info_filename,
-        Path("/") / config_file.sw_info_filename,
-        Path("/app") / config_file.sw_info_filename,
-    ]
-
-    sw_info_src = next((p for p in sw_info_paths if p.exists()), None)
-
     artifact_map = {
         config_file.quabo_ph_baseline_filename: calib_dir / config_file.quabo_ph_baseline_filename,
-        config_file.sw_info_filename: sw_info_src,
+        config_file.sw_info_filename: PanoPaths.tmp_dir() / config_file.sw_info_filename,
     }
     for base_name, src_path in artifact_map.items():
         if src_path and src_path.exists():

--- a/control/src/control/health.py
+++ b/control/src/control/health.py
@@ -135,39 +135,50 @@ def _check_grpc_daq_nodes() -> list[tuple[str, bool, str]]:
         if not node.module_ids:
             continue
         host, port = util.daq_grpc_endpoint(node, daq_config)
+        name = f"{node.ip_addr} ({host}:{port})"
         try:
             hc = HealthClient(host=host, port=port)
             control_ok = hc.check(_SVC_DAQ_CONTROL, timeout=5.0)
             data_ok = hc.check(_SVC_DAQ_DATA, timeout=5.0)
             detail = f"daq_control={'up' if control_ok else 'down'} daq_data={'up' if data_ok else 'down'}"
-            results.append((str(node.ip_addr), control_ok and data_ok, detail))
+            results.append((name, control_ok and data_ok, detail))
         except Exception as e:
-            results.append((str(node.ip_addr), False, str(e)))
+            results.append((name, False, str(e)))
     return results
 
 
-def _check_grpc_headnode() -> tuple[bool, str]:
+def _check_grpc_headnode() -> tuple[bool, str, int]:
     """Probe the head node's gRPC services on the endpoint a real client would use.
 
-    Resolving the port via ``util.resolve_grpc_port("headnode")`` (rather
-    than a hardcoded 50051) is what makes this a genuine desync check: it
-    tells us whether the server the operator's .env says should be
-    listening on HEADNODE_GRPC_PORT actually is -- catching exactly the bug
-    class where a server binds one port (stale TOML, forgotten --port-env)
-    while every client still assumes the default.
+    Resolving the port via ``util.resolve_grpc_port("headnode", explicit=...)``
+    (rather than a hardcoded 50051) is what makes this a genuine desync
+    check: it tells us whether the server the operator's config says should
+    be listening actually is -- catching exactly the bug class where a
+    server binds one port (stale TOML, forgotten --port-env) while every
+    client still assumes the default.
+
+    Precedence, highest first: network_config.json's ``headnode.grpc_port``
+    (if set) > the ``HEADNODE_GRPC_PORT`` env var > the 50051 default --
+    same three-tier resolution ``_check_grpc_daq_nodes()`` gets via
+    ``attach_daq_config()`` + ``daq_grpc_endpoint()``.
     """
     from panoseti_grpc.grpc_utils.health import HealthClient
 
-    from control.utils import util
+    from control.utils import config_file, util
 
-    port = util.resolve_grpc_port("headnode")
+    # get_network_config() always returns a NetworkConfig (falls back to an
+    # empty default on a missing/invalid file), so headnode.grpc_port is
+    # simply None when unset -- resolve_grpc_port() then falls through.
+    network_config = config_file.get_network_config()
+    port = util.resolve_grpc_port("headnode", explicit=network_config.headnode.grpc_port)
     try:
         hc = HealthClient(host="localhost", port=port)
         telemetry_ok = hc.check(_SVC_TELEMETRY, timeout=5.0)
         data_ok = hc.check(_SVC_DAQ_DATA, timeout=5.0)
-        return telemetry_ok or data_ok, f"telemetry={'up' if telemetry_ok else 'down'} daq_data(gateway)={'up' if data_ok else 'down'}"
+        detail = f"telemetry={'up' if telemetry_ok else 'down'} daq_data(gateway)={'up' if data_ok else 'down'}"
+        return telemetry_ok or data_ok, detail, port
     except Exception as e:
-        return False, f"localhost:{port} -- {e}"
+        return False, f"localhost:{port} -- {e}", port
 
 
 def _check_port_collision() -> list[tuple[str, bool, str]]:
@@ -175,12 +186,18 @@ def _check_port_collision() -> list[tuple[str, bool, str]]:
 
     On a single-machine deployment (e.g. Lick), the head and DAQ unified
     servers both run with network_mode: host, so they MUST resolve to
-    different ports -- if HEADNODE_GRPC_PORT and DAQNODE_GRPC_PORT resolve
-    to the same value on a node that is local to the head, the two servers
-    will fight over one port and one of them loses (see wiki_docs's
-    "Co-locating Head Node and DAQ Node" section). Likewise DAQ_DATA_DIR and
-    PSETI_DATA_DIR must not overlap, or the DAQ node's hashpipe output and
-    the head node's own service state corrupt each other.
+    different ports -- if the headnode and DAQ node resolve to the same
+    port on a node that is local to the head, the two servers will fight
+    over one port and one of them loses (see wiki_docs's "Co-locating Head
+    Node and DAQ Node" section). Likewise DAQ_DATA_DIR and PSETI_DATA_DIR
+    must not overlap, or the DAQ node's hashpipe output and the head node's
+    own service state corrupt each other.
+
+    Port precedence, highest first: network_config.json's ``headnode.grpc_port``
+    / a node's own ``grpc_port`` > the ``HEADNODE_GRPC_PORT`` / ``DAQNODE_GRPC_PORT``
+    env vars > the 50051 default -- same resolution ``_check_grpc_headnode()``
+    and ``_check_grpc_daq_nodes()`` use, so this collision check can't disagree
+    with what those two actually probe.
 
     Runs before any network I/O -- catches the misconfiguration that would
     otherwise surface later as "container keeps restarting" or silent data
@@ -194,19 +211,27 @@ def _check_port_collision() -> list[tuple[str, bool, str]]:
     except Exception as e:
         return [("config", False, f"could not load daq_config.json: {e}")]
 
-    head_port = util.resolve_grpc_port("headnode")
-    daq_port = util.resolve_grpc_port("daqnode")
+    network_config = config_file.get_network_config()
+    util.attach_daq_config(daq_config, network_config)
+
+    head_port = util.resolve_grpc_port("headnode", explicit=network_config.headnode.grpc_port)
     for node in daq_config.daq_nodes:
         if not util.is_local(node.ip_addr, daq_config):
             continue
+        # Matches daq_grpc_endpoint()'s own is_local branch: explicit
+        # per-node override (network_config.json, via attach_daq_config
+        # above, or daq_config.json's own field) beats the env var.
+        daq_port = util.resolve_grpc_port("daqnode", explicit=node.grpc_port)
         ok = head_port != daq_port
         results.append((
             str(node.ip_addr),
             ok,
-            f"HEADNODE_GRPC_PORT={head_port} DAQNODE_GRPC_PORT={daq_port}"
+            f"headnode grpc_port={head_port} daqnode grpc_port={daq_port}"
             if ok else
-            f"co-located with head node but HEADNODE_GRPC_PORT == DAQNODE_GRPC_PORT == {head_port} "
-            "-- set distinct values in .env (see wiki_docs's co-location guide)",
+            f"co-located with head node but headnode/daqnode grpc_port both resolve to {head_port} "
+            "-- set distinct values (network_config.json's headnode.grpc_port / "
+            "daq_nodes[].grpc_port, or HEADNODE_GRPC_PORT/DAQNODE_GRPC_PORT in .env; "
+            "see wiki_docs's co-location guide)",
         ))
 
         # DAQ_DATA_DIR/PSETI_DATA_DIR are compose-time env vars (see
@@ -321,8 +346,6 @@ def main(
     DAQ node + head node gRPC service health, container status, and the
     transfer daemon.
     """
-    from control.utils import util
-
     table = Table(title="PSETI Observatory Health", show_lines=False)
     table.add_column("Category", style="bold")
     table.add_column("Target")
@@ -359,8 +382,8 @@ def main(
             mark(pc_ok)
 
         console.print("[dim]Checking head node gRPC services...[/dim]")
-        hn_ok, hn_detail = _check_grpc_headnode()
-        _row(table, "gRPC", f"headnode (localhost:{util.resolve_grpc_port('headnode')})", hn_ok, hn_detail)
+        hn_ok, hn_detail, hn_port = _check_grpc_headnode()
+        _row(table, "gRPC", f"headnode (localhost:{hn_port})", hn_ok, hn_detail)
         mark(hn_ok)
 
         console.print("[dim]Checking DAQ node gRPC services...[/dim]")

--- a/control/src/control/pseti.py
+++ b/control/src/control/pseti.py
@@ -101,7 +101,10 @@ def main_callback(
         bool,
         typer.Option(
             "--env-template",
-            help="Copy the packaged .env.example to ./.env_pseti_<timestamp> and exit.",
+            help=(
+                "Copy the packaged .env.example to ./.env_pseti_<timestamp> and exit. "
+                "Point PSETI_ENV_FILE at the generated file to load it."
+            ),
             callback=_env_template_callback,
             is_eager=True,
         ),

--- a/control/src/control/start_preflight.py
+++ b/control/src/control/start_preflight.py
@@ -293,8 +293,10 @@ async def _check_daq_data_status(
         # The gateway *is* the head node's unified server -- resolve_grpc_port
         # keeps this in sync with every other headnode client (and with
         # DAQ_DATA_GATEWAY_PORT as a deprecated fallback) instead of reading
-        # that one env var directly.
-        gateway_port = util.resolve_grpc_port("headnode")
+        # that one env var directly. network_config.json's headnode.grpc_port
+        # (if set) takes precedence over the env var / default, same as
+        # _check_grpc_headnode()/_check_port_collision()/show_cli.py.
+        gateway_port = util.resolve_grpc_port("headnode", explicit=network_config.headnode.grpc_port)
 
     logger.info("Performing DaqData gateway status pre-flight check...")
 

--- a/control/src/control/status.py
+++ b/control/src/control/status.py
@@ -70,7 +70,7 @@ def _local_summary() -> list[Text]:
 
     hk_running = util.is_hk_recorder_running()
     hk_style = "green" if hk_running else "red"
-    lines.append(Text.assemble(("HK rec:  ", "bold"), (f"{'running' if hk_running else 'stopped'}", hk_style)))
+    lines.append(Text.assemble(("HK Recorder: ", "bold"), (f"{'RUNNING' if hk_running else 'STOPPED'}", hk_style)))
 
     age = _transfer_daemon_age()
     if age is None:
@@ -152,7 +152,7 @@ async def _remote_summary(
             hp_style = "green" if hp_running else "red"
             pid = status.get('hashpipe_pid')
             pid_str = f" (PID:{pid})" if pid else ""
-            hp_parts: list[Any] = [(f"HP: {hp_state}", hp_style), f"{pid_str}"]
+            hp_parts: list[Any] = [(f"HASHPIPE: {hp_state}", hp_style), f"{pid_str}"]
             if hp_running:
                 thread_count = status.get("hashpipe_thread_count", 0)
                 healthy = status.get("hashpipe_healthy", True)
@@ -189,7 +189,7 @@ async def _remote_summary(
             summary = Text.assemble(
                 f"  • {ip_str:<14} | ",
                 hp_text,
-                " " * max(0, 16 - len(hp_text.plain)),
+                " " * max(0, 22 - len(hp_text.plain)),
                 "| ",
                 (disk_str, disk_style),
                 " " * max(0, 28 - len(disk_str)),

--- a/control/src/control/stop_transaction.py
+++ b/control/src/control/stop_transaction.py
@@ -188,7 +188,8 @@ class StopTransaction:
                                 username=n.username,
                                 data_dir=n.data_dir,
                                 module_ids=n.module_ids,
-                                port_forwarding=n.port_forwarding
+                                port_forwarding=n.port_forwarding,
+                                grpc_port=n.grpc_port
                             )
                             for n in self.daq_config.daq_nodes if n.module_ids
                         ]

--- a/control/src/control/tools/show_cli.py
+++ b/control/src/control/tools/show_cli.py
@@ -21,7 +21,7 @@ from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
 
-from control.utils import util
+from control.utils import config_file, util
 from control.utils.env_loader import get_env_info
 from control.utils.paths import PanoPaths
 
@@ -288,7 +288,10 @@ async def stream_sci_data(
     # The gateway is the head node's unified server -- resolve_grpc_port keeps
     # this in sync with every other headnode client (DAQ_DATA_GATEWAY_PORT is
     # honored as a deprecated fallback, not read directly here anymore).
-    gateway_port = util.resolve_grpc_port("headnode")
+    # network_config.json's headnode.grpc_port (if set) takes precedence over
+    # the env var / default, same as _check_grpc_headnode()/_check_port_collision().
+    network_config = config_file.get_network_config()
+    gateway_port = util.resolve_grpc_port("headnode", explicit=network_config.headnode.grpc_port)
 
     # Shared state between ingestion and rendering
     latest_images: dict[int, dict[str, dict[Any, Any]]] = {}

--- a/control/src/control/tools/skymap_helper.py
+++ b/control/src/control/tools/skymap_helper.py
@@ -11,6 +11,9 @@ from typing import Any
 
 import redis
 
+from control.utils import config_file
+from control.utils.paths import PanoPaths
+
 
 # Add obs config to the skymap template.
 # The obs config is from obs_config.json by default.
@@ -44,10 +47,12 @@ def add_data_config(skymap_t: dict[str, Any], data_config_file: str = 'data_conf
 # Add software version info to the skymap template.
 # The software version is from sw_info.json by default. 
 # 
-def add_sw_info(skymap_t: dict[str, Any], sw: str = 'Production', Ver: str = 'V0.0.1', sw_info_file: str = 'sw_info.json') -> None:
+def add_sw_info(skymap_t: dict[str, Any], sw: str = 'Production', Ver: str = 'V0.0.1', sw_info_file: str | None = None) -> None:
     skymap_t['software_config']['type'] = sw
     # if it's production code, we will get the Ver from sw_info.json
     if(sw == 'Production'):
+        if sw_info_file is None:
+            sw_info_file = str(PanoPaths.tmp_dir() / config_file.sw_info_filename)
         with open(sw_info_file) as f:
             sw_info = json.load(f)
         skymap_t['software_config']['version'] = sw_info['commit']

--- a/control/src/control/tools/sw_info.py
+++ b/control/src/control/tools/sw_info.py
@@ -2,6 +2,7 @@
 import json
 
 from control.utils import config_file
+from control.utils.paths import PanoPaths
 
 
 def get_sw_info() -> None:
@@ -22,8 +23,10 @@ def get_sw_info() -> None:
                  'branch':'unknown',\
                  'commit_date':'unknown',
                  'error': str(e)}
-                 
-    with open(config_file.sw_info_filename,'w') as f:
+
+    tmp_dir = PanoPaths.tmp_dir()
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    with open(tmp_dir / config_file.sw_info_filename, 'w') as f:
         json.dump(sw_info, f, indent=4)
 
 if __name__ == '__main__':

--- a/control/src/control/transfer/cli.py
+++ b/control/src/control/transfer/cli.py
@@ -207,14 +207,15 @@ def retry(run_name: Annotated[str, typer.Argument(help="Run name to retry")]) ->
 
 
 @app.command()
-def clean(run_name: Annotated[str, typer.Argument(help="Run name to remove from pending/")]) -> None:
-    """Remove a job from pending/ and try to delete its run directory on each DAQ node.
+def clean(run_name: Annotated[str, typer.Argument(help="Run name to remove from pending/ or failed/")]) -> None:
+    """Remove a job from pending/ or failed/ and try to delete its run directory on each DAQ node.
 
-    The job never reached manifest generation, so there's no verified manifest to
-    checksum against -- this uses CLEANUP_FULL (removes the whole run directory on
-    each DAQ node) rather than the daemon's own selective, manifest-gated cleanup.
-    DAQ-node deletion is best-effort: a node that's unreachable or errors out is
-    reported as a warning but does not undo the local pending/ removal.
+    Checks pending/ first, then failed/. The job never reached (or never completed)
+    manifest generation, so there's no verified manifest to checksum against -- this
+    uses CLEANUP_FULL (removes the whole run directory on each DAQ node) rather than
+    the daemon's own selective, manifest-gated cleanup. DAQ-node deletion is
+    best-effort: a node that's unreachable or errors out is reported as a warning but
+    does not undo the local queue removal.
     """
     from control.transfer.daq_control import cleanup_daq_nodes
     from control.transfer.queue import TransferQueue
@@ -224,10 +225,10 @@ def clean(run_name: Annotated[str, typer.Argument(help="Run name to remove from 
 
     job = tq.clean(run_name)
     if job is None:
-        console.print(f"[bold red]Error:[/bold red] No pending job found for '{run_name}'")
+        console.print(f"[bold red]Error:[/bold red] No pending or failed job found for '{run_name}'")
         raise typer.Exit(1)
 
-    console.print(f"[bold green]Success:[/bold green] Removed {run_name} from pending/")
+    console.print(f"[bold green]Success:[/bold green] Removed {run_name} from the transfer queue")
 
     errors = asyncio.run(cleanup_daq_nodes(job, mode="CLEANUP_FULL"))
     if errors:

--- a/control/src/control/transfer/queue.py
+++ b/control/src/control/transfer/queue.py
@@ -227,10 +227,11 @@ class TransferQueue:
         return True
 
     def clean(self, run_name: str) -> TransferJob | None:
-        """Remove a job from pending/ so the daemon never claims it.
+        """Remove a job from pending/ or failed/ so the daemon never (re-)claims it.
 
-        Only ``pending/`` is targeted: a job already claimed into ``active/``
-        is already being transferred and can't be safely skipped this way.
+        Checks ``pending/`` first, then ``failed/``. Neither ``active/`` (a
+        job already claimed and being transferred, which can't be safely
+        skipped this way) nor ``completed/`` is touched.
 
         Args:
             run_name: The run identifier of the job to remove.
@@ -238,16 +239,18 @@ class TransferQueue:
         Returns:
             The removed ``TransferJob`` (so callers can still see which DAQ
             nodes it named, e.g. to also clean up remotely), or ``None`` if
-            no pending job existed for *run_name*.
+            no pending or failed job existed for *run_name*.
         """
-        path = self._job_path(TransferStatus.PENDING, run_name)
-        if not path.exists():
-            return None
-        with open(path, "rb") as f:
-            data = tomllib.load(f)
-        job = TransferJob.model_validate(data)
-        os.unlink(path)
-        return job
+        for subdir in (TransferStatus.PENDING, TransferStatus.FAILED):
+            path = self._job_path(subdir, run_name)
+            if not path.exists():
+                continue
+            with open(path, "rb") as f:
+                data = tomllib.load(f)
+            job = TransferJob.model_validate(data)
+            os.unlink(path)
+            return job
+        return None
 
     def list_jobs(self, bucket: TransferStatus) -> list[str]:
         """Return run names in a queue bucket.

--- a/control/src/control/transfer/queue.py
+++ b/control/src/control/transfer/queue.py
@@ -98,6 +98,11 @@ class TransferQueue:
                     for k, v in node.items():
                         if k == "port_forwarding":
                             continue
+                        if v is None:
+                            # Optional fields (e.g. grpc_port) -- omit rather
+                            # than writing the literal string "None", which
+                            # would round-trip as a str, not int | None.
+                            continue
                         if isinstance(v, list):
                             # module_ids is a list of ints
                             f.write(f"{k} = [{', '.join(str(i) for i in v)}]\n")

--- a/control/src/control/utils/pydantic_config_models.py
+++ b/control/src/control/utils/pydantic_config_models.py
@@ -562,6 +562,13 @@ class TransferNodeSpec(BaseStrictModel):
     data_dir: str
     module_ids: list[int]
     port_forwarding: PortForwarding | None = None
+    # Mirrors DaqNode.grpc_port -- the direct-connection gRPC port override
+    # from daq_config.json/network_config.json, snapshotted at enqueue time
+    # so the Transfer Daemon (which never reloads daq_config.json) resolves
+    # the same port a live client would via daq_grpc_endpoint(). None means
+    # "no override": daq_grpc_endpoint() falls back to the fleet-wide
+    # DAQNODE_GRPC_PORT env var / 50051 default.
+    grpc_port: int | None = Field(None, ge=1, le=65535, description="Direct-connection gRPC port override")
 
 
 class TransferJob(BaseStrictModel):

--- a/control/src/control/utils/pydantic_config_models.py
+++ b/control/src/control/utils/pydantic_config_models.py
@@ -395,10 +395,30 @@ class NetworkModule(BaseStrictModel):
 class NetworkDaqNode(BaseStrictModel):
     """Network-level mapping for a DAQ node."""
     ip_addr: IPvAnyAddress
+    # Direct-connection gRPC port -- used when port_forwarding.status is
+    # False (or absent), i.e. this node is reached directly at ip_addr
+    # rather than through a forwarded gateway. Distinct from
+    # port_forwarding.grpc_port, which only applies when status is True.
+    # None (the default when omitted from network_config.json) means "not
+    # set here" -- attach_daq_config() then seeds it onto daq_config.json's
+    # DaqNode.grpc_port (only if that field is itself unset), so
+    # daq_grpc_endpoint() ultimately falls through to the fleet-wide
+    # DAQNODE_GRPC_PORT env var / 50051 default when neither is set.
+    grpc_port: int | None = Field(None, ge=1, le=65535)
     port_forwarding: PortForwarding
+
+class NetworkHeadnode(BaseStrictModel):
+    """Network-level configuration for the head node itself."""
+    # None (the default when omitted from network_config.json) means "not
+    # set here" -- callers pass this straight through as
+    # resolve_grpc_port("headnode", explicit=...)'s explicit override, so
+    # they fall through to the HEADNODE_GRPC_PORT env var / 50051 default
+    # when it's unset.
+    grpc_port: int | None = Field(None, ge=1, le=65535)
 
 class NetworkConfig(BaseStrictModel):
     """Global network routing and port-forwarding map (network_config.json)."""
+    headnode: NetworkHeadnode = Field(default_factory=NetworkHeadnode)
     modules: list[NetworkModule] = Field(default_factory=list)
     daq_nodes: list[NetworkDaqNode] = Field(default_factory=list)
 

--- a/control/src/control/utils/util.py
+++ b/control/src/control/utils/util.py
@@ -937,6 +937,15 @@ def attach_daq_config(
                     # Only overwrite if pdaq has a non-None port_forwarding block
                     if pdaq.port_forwarding is not None:
                         daq.port_forwarding = pdaq.port_forwarding
+                    # network_config.json's direct-connect grpc_port is a
+                    # fleet-wide-ish default; daq_config.json's own explicit
+                    # override (if the operator set one directly on this
+                    # node) still wins -- only fill in when daq's own field
+                    # is unset, so daq_grpc_endpoint()'s existing precedence
+                    # (explicit > env var > 50051) gains network_config as a
+                    # new middle tier without any change to that function.
+                    if daq.grpc_port is None and pdaq.grpc_port is not None:
+                        daq.grpc_port = pdaq.grpc_port
                     break
 
 

--- a/control/uv.lock
+++ b/control/uv.lock
@@ -1232,7 +1232,7 @@ wheels = [
 
 [[package]]
 name = "panoseti-grpc"
-version = "0.4.19"
+version = "0.4.20"
 source = { editable = "../grpc" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- `--env-template` help text now points users at `PSETI_ENV_FILE` for loading the generated template.
- `sw_info.json` is now written to `PanoPaths.tmp_dir()` (PSETI_TMP-overridable) instead of the CWD-relative path it used before -- `hardware_ops.py`'s run-dir snapshot step and `skymap_helper.add_sw_info()` now read it from the same deterministic location instead of probing multiple candidate paths.
- `network_config.json` gains two new fields: a top-level `headnode.grpc_port` and, per DAQ node, a sibling `grpc_port` (alongside `ip_addr`) used for direct connections when `port_forwarding.status` is `False`. Both default to `None` so callers can distinguish "explicitly set" from "field default".
- `attach_daq_config()` seeds `daq_config.json`'s own `DaqNode.grpc_port` from the new network_config sibling field when the node's own value is unset (its own explicit override still wins) -- `daq_grpc_endpoint()` itself needed no changes to pick this up.
- `health.py`'s `_check_grpc_headnode()`, `_check_grpc_daq_nodes()`, and `_check_port_collision()`, plus `start_preflight.py`'s DaqData gateway pre-flight check and `show_cli.py`'s `pseti show sci`, all now resolve ports with `network_config.json` taking precedence over `HEADNODE_GRPC_PORT`/`DAQNODE_GRPC_PORT`, which remain the fallback.
- `grpc` submodule bumped to `v0.4.20` (adds `PSETI_GRPC_HOST`/`PSETI_GRPC_PORT` CLI defaults, `--config-template`, and the matching `network_config.json` schema on the `panoseti_grpc` side); `control/uv.lock` synced.
- CI fixture `network_config.json` files updated with the new fields for the config-validation regression tests.

## Test plan
- [x] `ruff`/`mypy` pass on all changed files
- [x] `tier1_unit` + `tier2_logic` (947 tests) pass, including new coverage for `attach_daq_config()`'s network_config seeding and `_check_port_collision()`'s precedence
- [x] Manually verified `sw_info.json`'s new write/read location and the `network_config.json` > env var > default port precedence